### PR TITLE
feat: implement export evaluation admin

### DIFF
--- a/COMMITMENT
+++ b/COMMITMENT
@@ -1,0 +1,46 @@
+GPL Cooperation Commitment
+Version 1.0
+
+Before filing or continuing to prosecute any legal proceeding or claim
+(other than a Defensive Action) arising from termination of a Covered
+License, we commit to extend to the person or entity ('you') accused
+of violating the Covered License the following provisions regarding
+cure and reinstatement, taken from GPL version 3. As used here, the
+term 'this License' refers to the specific Covered License being
+enforced.
+
+    However, if you cease all violation of this License, then your
+    license from a particular copyright holder is reinstated (a)
+    provisionally, unless and until the copyright holder explicitly
+    and finally terminates your license, and (b) permanently, if the
+    copyright holder fails to notify you of the violation by some
+    reasonable means prior to 60 days after the cessation.
+
+    Moreover, your license from a particular copyright holder is
+    reinstated permanently if the copyright holder notifies you of the
+    violation by some reasonable means, this is the first time you
+    have received notice of violation of this License (for any work)
+    from that copyright holder, and you cure the violation prior to 30
+    days after your receipt of the notice.
+
+We intend this Commitment to be irrevocable, and binding and
+enforceable against us and assignees of or successors to our
+copyrights.
+
+Definitions
+
+'Covered License' means the GNU General Public License, version 2
+(GPLv2), the GNU Lesser General Public License, version 2.1
+(LGPLv2.1), or the GNU Library General Public License, version 2
+(LGPLv2), all as published by the Free Software Foundation.
+
+'Defensive Action' means a legal proceeding or claim that We bring
+against you in response to a prior proceeding or claim initiated by
+you or your affiliate.
+
+'We' means each contributor to this repository as of the date of
+inclusion of this file, including subsidiaries of a corporate
+contributor.
+
+This work is available under a Creative Commons Attribution-ShareAlike
+4.0 International license (https://creativecommons.org/licenses/by-sa/4.0/).

--- a/check_username.php
+++ b/check_username.php
@@ -1,0 +1,26 @@
+<?php
+require_once 'includes/config.php';
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['username'])) {
+    $username = trim($_POST['username']);
+    
+    $conn = getDB();
+    $stmt = $conn->prepare("SELECT id FROM users WHERE username = ?");
+    $stmt->bind_param("s", $username);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    
+    if ($result->num_rows > 0) {
+        echo json_encode(['available' => false]);
+    } else {
+        echo json_encode(['available' => true]);
+    }
+    
+    $stmt->close();
+    $conn->close();
+} else {
+    echo json_encode(['error' => 'Invalid request']);
+}
+?>

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,84 @@
+{
+    "name": "phpmailer/phpmailer",
+    "type": "library",
+    "description": "PHPMailer is a full-featured email creation and transfer class for PHP",
+    "authors": [
+        {
+            "name": "Marcus Bointon",
+            "email": "phpmailer@synchromedia.co.uk"
+        },
+        {
+            "name": "Jim Jagielski",
+            "email": "jimjag@gmail.com"
+        },
+        {
+            "name": "Andy Prevost",
+            "email": "codeworxtech@users.sourceforge.net"
+        },
+        {
+            "name": "Brent R. Matzelle"
+        }
+    ],
+    "funding": [
+        {
+            "url": "https://github.com/Synchro",
+            "type": "github"
+        }
+    ],
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        },
+        "lock": false
+    },
+    "require": {
+        "php": ">=5.5.0",
+        "ext-ctype": "*",
+        "ext-filter": "*",
+        "ext-hash": "*"
+    },
+    "require-dev": {
+        "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+        "doctrine/annotations": "^1.2.6 || ^1.13.3",
+        "php-parallel-lint/php-console-highlighter": "^1.0.0",
+        "php-parallel-lint/php-parallel-lint": "^1.3.2",
+        "phpcompatibility/php-compatibility": "^10.0.0@dev",
+        "squizlabs/php_codesniffer": "^3.13.5",
+        "yoast/phpunit-polyfills": "^1.0.4"
+    },
+    "suggest": {
+        "decomplexity/SendOauth2": "Adapter for using XOAUTH2 authentication",
+        "ext-imap": "Needed to support advanced email address parsing according to RFC822",
+        "ext-mbstring": "Needed to send email in multibyte encoding charset or decode encoded addresses",
+        "ext-openssl": "Needed for secure SMTP sending and DKIM signing",
+        "greew/oauth2-azure-provider": "Needed for Microsoft Azure XOAUTH2 authentication",
+        "hayageek/oauth2-yahoo": "Needed for Yahoo XOAUTH2 authentication",
+        "league/oauth2-google": "Needed for Google XOAUTH2 authentication",
+        "psr/log": "For optional PSR-3 debug logging",
+        "symfony/polyfill-mbstring": "To support UTF-8 if the Mbstring PHP extension is not enabled (^1.2)",
+        "thenetworg/oauth2-azure": "Needed for Microsoft XOAUTH2 authentication",
+        "directorytree/imapengine": "For uploading sent messages via IMAP, see gmail example"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "autoload": {
+        "psr-4": {
+            "PHPMailer\\PHPMailer\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "PHPMailer\\Test\\": "test/"
+        }
+    },
+    "license": "LGPL-2.1-only",
+    "scripts": {
+        "check": "./vendor/bin/phpcs",
+        "style": "./vendor/bin/phpcbf",
+        "test": "./vendor/bin/phpunit --no-coverage",
+        "coverage": "./vendor/bin/phpunit",
+        "lint": [
+            "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . --show-deprecated -e php,phps --exclude vendor --exclude .git --exclude build"
+        ]
+    }
+}

--- a/create_admin.php
+++ b/create_admin.php
@@ -1,0 +1,20 @@
+<?php
+require_once 'includes/config.php';
+
+// Update admin password
+$new_password = password_hash('admin123', PASSWORD_DEFAULT);
+$sql = "UPDATE users SET password = ? WHERE username = 'admin'";
+
+$stmt = $conn->prepare($sql);
+$stmt->bind_param("s", $new_password);
+
+if ($stmt->execute()) {
+    echo "Admin password reset successfully!<br>";
+    echo "New password: admin123";
+} else {
+    echo "Error updating password: " . $conn->error;
+}
+
+$stmt->close();
+$conn->close();
+?>

--- a/language/phpmailer.lang-af.php
+++ b/language/phpmailer.lang-af.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Afrikaans PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP-fout: kon nie geverifieer word nie.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP-fout: kon nie aan SMTP-verbind nie.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP-fout: data nie aanvaar nie.';
+$PHPMAILER_LANG['empty_message']        = 'Boodskapliggaam leeg.';
+$PHPMAILER_LANG['encoding']             = 'Onbekende kodering: ';
+$PHPMAILER_LANG['execute']              = 'Kon nie uitvoer nie: ';
+$PHPMAILER_LANG['file_access']          = 'Kon nie lêer oopmaak nie: ';
+$PHPMAILER_LANG['file_open']            = 'Lêerfout: Kon nie lêer oopmaak nie: ';
+$PHPMAILER_LANG['from_failed']          = 'Die volgende Van adres misluk: ';
+$PHPMAILER_LANG['instantiate']          = 'Kon nie posfunksie instansieer nie.';
+$PHPMAILER_LANG['invalid_address']      = 'Ongeldige adres: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' mailer word nie ondersteun nie.';
+$PHPMAILER_LANG['provide_address']      = 'U moet ten minste een ontvanger e-pos adres verskaf.';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP-fout: Die volgende ontvangers het misluk: ';
+$PHPMAILER_LANG['signing']              = 'Ondertekening Fout: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP-verbinding () misluk.';
+$PHPMAILER_LANG['smtp_error']           = 'SMTP-bediener fout: ';
+$PHPMAILER_LANG['variable_set']         = 'Kan nie veranderlike instel of herstel nie: ';
+$PHPMAILER_LANG['extension_missing']    = 'Uitbreiding ontbreek: ';

--- a/language/phpmailer.lang-ar.php
+++ b/language/phpmailer.lang-ar.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Arabic PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author bahjat al mostafa <bahjat983@hotmail.com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'خطأ SMTP : لا يمكن تأكيد الهوية.';
+$PHPMAILER_LANG['connect_host']         = 'خطأ SMTP: لا يمكن الاتصال بالخادم SMTP.';
+$PHPMAILER_LANG['data_not_accepted']    = 'خطأ SMTP: لم يتم قبول المعلومات .';
+$PHPMAILER_LANG['empty_message']        = 'نص الرسالة فارغ';
+$PHPMAILER_LANG['encoding']             = 'ترميز غير معروف: ';
+$PHPMAILER_LANG['execute']              = 'لا يمكن تنفيذ : ';
+$PHPMAILER_LANG['file_access']          = 'لا يمكن الوصول للملف: ';
+$PHPMAILER_LANG['file_open']            = 'خطأ في الملف: لا يمكن فتحه: ';
+$PHPMAILER_LANG['from_failed']          = 'خطأ على مستوى عنوان المرسل : ';
+$PHPMAILER_LANG['instantiate']          = 'لا يمكن توفير خدمة البريد.';
+$PHPMAILER_LANG['invalid_address']      = 'الإرسال غير ممكن لأن عنوان البريد الإلكتروني غير صالح: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' برنامج الإرسال غير مدعوم.';
+$PHPMAILER_LANG['provide_address']      = 'يجب توفير عنوان البريد الإلكتروني لمستلم واحد على الأقل.';
+$PHPMAILER_LANG['recipients_failed']    = 'خطأ SMTP: الأخطاء التالية فشل في الارسال لكل من : ';
+$PHPMAILER_LANG['signing']              = 'خطأ في التوقيع: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() غير ممكن.';
+$PHPMAILER_LANG['smtp_error']           = 'خطأ على مستوى الخادم SMTP: ';
+$PHPMAILER_LANG['variable_set']         = 'لا يمكن تعيين أو إعادة تعيين متغير: ';
+$PHPMAILER_LANG['extension_missing']    = 'الإضافة غير موجودة: ';

--- a/language/phpmailer.lang-as.php
+++ b/language/phpmailer.lang-as.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Assamese PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Manish Sarkar <manish.n.manish@gmail.com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP ত্ৰুটি: প্ৰমাণীকৰণ কৰিব নোৱাৰি';
+$PHPMAILER_LANG['buggy_php']            = 'আপোনাৰ PHP সংস্কৰণ এটা বাগৰ দ্বাৰা প্ৰভাৱিত হয় যাৰ ফলত নষ্ট বাৰ্তা হব পাৰে । ইয়াক সমাধান কৰিবলে, প্ৰেৰণ কৰিবলে SMTP ব্যৱহাৰ কৰক, আপোনাৰ php.ini ত mail.add_x_header বিকল্প নিষ্ক্ৰিয় কৰক, MacOS বা Linux লৈ সলনি কৰক, বা আপোনাৰ PHP সংস্কৰণ 7.0.17+ বা 7.1.3+ লৈ সলনি কৰক ।';
+$PHPMAILER_LANG['connect_host']         = 'SMTP ত্ৰুটি: SMTP চাৰ্ভাৰৰ সৈতে সংযোগ কৰিবলে অক্ষম';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP ত্ৰুটি: তথ্য গ্ৰহণ কৰা হোৱা নাই';
+$PHPMAILER_LANG['empty_message']        = 'বাৰ্তাৰ মূখ্য অংশ খালী।';
+$PHPMAILER_LANG['encoding']             = 'অজ্ঞাত এনকোডিং: ';
+$PHPMAILER_LANG['execute']              = 'এক্সিকিউট কৰিব নোৱাৰি: ';
+$PHPMAILER_LANG['extension_missing']    = 'সম্প্ৰসাৰণ নোহোৱা হৈছে: ';
+$PHPMAILER_LANG['file_access']          = 'ফাইল অভিগম কৰিবলে অক্ষম: ';
+$PHPMAILER_LANG['file_open']            = 'ফাইল ত্ৰুটি: ফাইল খোলিবলৈ অক্ষম: ';
+$PHPMAILER_LANG['from_failed']          = 'নিম্নলিখিত প্ৰেৰকৰ ঠিকনা(সমূহ) ব্যৰ্থ: ';
+$PHPMAILER_LANG['instantiate']          = 'মেইল ফাংচনৰ এটা উদাহৰণ সৃষ্টি কৰিবলে অক্ষম';
+$PHPMAILER_LANG['invalid_address']      = 'প্ৰেৰণ কৰিব নোৱাৰি: অবৈধ ইমেইল ঠিকনা: ';
+$PHPMAILER_LANG['invalid_header']       = 'অবৈধ হেডাৰৰ নাম বা মান';
+$PHPMAILER_LANG['invalid_hostentry']    = 'অবৈধ হোষ্টেন্ট্ৰি: ';
+$PHPMAILER_LANG['invalid_host']         = 'অবৈধ হস্ট:';
+$PHPMAILER_LANG['mailer_not_supported'] = 'মেইলাৰ সমৰ্থিত নহয়।';
+$PHPMAILER_LANG['provide_address']      = 'আপুনি অন্ততঃ এটা গন্তব্য ইমেইল ঠিকনা দিব লাগিব';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP ত্ৰুটি: নিম্নলিখিত গন্তব্যস্থানসমূহ ব্যৰ্থ: ';
+$PHPMAILER_LANG['signing']              = 'স্বাক্ষৰ কৰাত ব্যৰ্থ: ';
+$PHPMAILER_LANG['smtp_code']            = 'SMTP কড: ';
+$PHPMAILER_LANG['smtp_code_ex']         = 'অতিৰিক্ত SMTP তথ্য: ';
+$PHPMAILER_LANG['smtp_detail']          = 'বিৱৰণ:';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP সংযোগ() ব্যৰ্থ';
+$PHPMAILER_LANG['smtp_error']           = 'SMTP চাৰ্ভাৰৰ ত্ৰুটি: ';
+$PHPMAILER_LANG['variable_set']         = 'চলক নিৰ্ধাৰণ কৰিব পৰা নগল: ';
+$PHPMAILER_LANG['extension_missing']    = 'অনুপস্থিত সম্প্ৰসাৰণ: ';

--- a/language/phpmailer.lang-az.php
+++ b/language/phpmailer.lang-az.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Azerbaijani PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author @mirjalal
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP xətası: Giriş uğursuz oldu.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP xətası: SMTP serverinə qoşulma uğursuz oldu.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP xətası: Verilənlər qəbul edilməyib.';
+$PHPMAILER_LANG['empty_message']        = 'Boş mesaj göndərilə bilməz.';
+$PHPMAILER_LANG['encoding']             = 'Qeyri-müəyyən kodlaşdırma: ';
+$PHPMAILER_LANG['execute']              = 'Əmr yerinə yetirilmədi: ';
+$PHPMAILER_LANG['file_access']          = 'Fayla giriş yoxdur: ';
+$PHPMAILER_LANG['file_open']            = 'Fayl xətası: Fayl açıla bilmədi: ';
+$PHPMAILER_LANG['from_failed']          = 'Göstərilən poçtlara göndərmə uğursuz oldu: ';
+$PHPMAILER_LANG['instantiate']          = 'Mail funksiyası işə salına bilmədi.';
+$PHPMAILER_LANG['invalid_address']      = 'Düzgün olmayan e-mail adresi: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' - e-mail kitabxanası dəstəklənmir.';
+$PHPMAILER_LANG['provide_address']      = 'Ən azı bir e-mail adresi daxil edilməlidir.';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP xətası: Aşağıdakı ünvanlar üzrə alıcılara göndərmə uğursuzdur: ';
+$PHPMAILER_LANG['signing']              = 'İmzalama xətası: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP serverinə qoşulma uğursuz oldu.';
+$PHPMAILER_LANG['smtp_error']           = 'SMTP serveri xətası: ';
+$PHPMAILER_LANG['variable_set']         = 'Dəyişənin quraşdırılması uğursuz oldu: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/language/phpmailer.lang-ba.php
+++ b/language/phpmailer.lang-ba.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Bosnian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Ermin Islamagić <ermin@islamagic.com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP Greška: Neuspjela prijava.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP Greška: Nije moguće spojiti se sa SMTP serverom.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP Greška: Podatci nisu prihvaćeni.';
+$PHPMAILER_LANG['empty_message']        = 'Sadržaj poruke je prazan.';
+$PHPMAILER_LANG['encoding']             = 'Nepoznata kriptografija: ';
+$PHPMAILER_LANG['execute']              = 'Nije moguće izvršiti naredbu: ';
+$PHPMAILER_LANG['file_access']          = 'Nije moguće pristupiti datoteci: ';
+$PHPMAILER_LANG['file_open']            = 'Nije moguće otvoriti datoteku: ';
+$PHPMAILER_LANG['from_failed']          = 'SMTP Greška: Slanje sa navedenih e-mail adresa nije uspjelo: ';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP Greška: Slanje na navedene e-mail adrese nije uspjelo: ';
+$PHPMAILER_LANG['instantiate']          = 'Ne mogu pokrenuti mail funkcionalnost.';
+$PHPMAILER_LANG['invalid_address']      = 'E-mail nije poslan. Neispravna e-mail adresa: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' mailer nije podržan.';
+$PHPMAILER_LANG['provide_address']      = 'Definišite barem jednu adresu primaoca.';
+$PHPMAILER_LANG['signing']              = 'Greška prilikom prijave: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'Spajanje na SMTP server nije uspjelo.';
+$PHPMAILER_LANG['smtp_error']           = 'SMTP greška: ';
+$PHPMAILER_LANG['variable_set']         = 'Nije moguće postaviti varijablu ili je vratiti nazad: ';
+$PHPMAILER_LANG['extension_missing']    = 'Nedostaje ekstenzija: ';

--- a/language/phpmailer.lang-be.php
+++ b/language/phpmailer.lang-be.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Belarusian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Aleksander Maksymiuk <info@setpro.pl>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'Памылка SMTP: памылка ідэнтыфікацыі.';
+$PHPMAILER_LANG['connect_host']         = 'Памылка SMTP: нельга ўстанавіць сувязь з SMTP-серверам.';
+$PHPMAILER_LANG['data_not_accepted']    = 'Памылка SMTP: звесткі непрынятыя.';
+$PHPMAILER_LANG['empty_message']        = 'Пустое паведамленне.';
+$PHPMAILER_LANG['encoding']             = 'Невядомая кадыроўка тэксту: ';
+$PHPMAILER_LANG['execute']              = 'Нельга выканаць каманду: ';
+$PHPMAILER_LANG['file_access']          = 'Няма доступу да файла: ';
+$PHPMAILER_LANG['file_open']            = 'Нельга адкрыць файл: ';
+$PHPMAILER_LANG['from_failed']          = 'Няправільны адрас адпраўніка: ';
+$PHPMAILER_LANG['instantiate']          = 'Нельга прымяніць функцыю mail().';
+$PHPMAILER_LANG['invalid_address']      = 'Нельга даслаць паведамленне, няправільны email атрымальніка: ';
+$PHPMAILER_LANG['provide_address']      = 'Запоўніце, калі ласка, правільны email атрымальніка.';
+$PHPMAILER_LANG['mailer_not_supported'] = ' - паштовы сервер не падтрымліваецца.';
+$PHPMAILER_LANG['recipients_failed']    = 'Памылка SMTP: няправільныя атрымальнікі: ';
+$PHPMAILER_LANG['signing']              = 'Памылка подпісу паведамлення: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'Памылка сувязі з SMTP-серверам.';
+$PHPMAILER_LANG['smtp_error']           = 'Памылка SMTP: ';
+$PHPMAILER_LANG['variable_set']         = 'Нельга ўстанавіць або перамяніць значэнне пераменнай: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/language/phpmailer.lang-bg.php
+++ b/language/phpmailer.lang-bg.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Bulgarian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Mikhail Kyosev <mialygk@gmail.com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP грешка: Не може да се удостовери пред сървъра.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP грешка: Не може да се свърже с SMTP хоста.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP грешка: данните не са приети.';
+$PHPMAILER_LANG['empty_message']        = 'Съдържанието на съобщението е празно';
+$PHPMAILER_LANG['encoding']             = 'Неизвестно кодиране: ';
+$PHPMAILER_LANG['execute']              = 'Не може да се изпълни: ';
+$PHPMAILER_LANG['file_access']          = 'Няма достъп до файл: ';
+$PHPMAILER_LANG['file_open']            = 'Файлова грешка: Не може да се отвори файл: ';
+$PHPMAILER_LANG['from_failed']          = 'Следните адреси за подател са невалидни: ';
+$PHPMAILER_LANG['instantiate']          = 'Не може да се инстанцира функцията mail.';
+$PHPMAILER_LANG['invalid_address']      = 'Невалиден адрес: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' - пощенски сървър не се поддържа.';
+$PHPMAILER_LANG['provide_address']      = 'Трябва да предоставите поне един email адрес за получател.';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP грешка: Следните адреси за Получател са невалидни: ';
+$PHPMAILER_LANG['signing']              = 'Грешка при подписване: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP провален connect().';
+$PHPMAILER_LANG['smtp_error']           = 'SMTP сървърна грешка: ';
+$PHPMAILER_LANG['variable_set']         = 'Не може да се установи или възстанови променлива: ';
+$PHPMAILER_LANG['extension_missing']    = 'Липсва разширение: ';

--- a/language/phpmailer.lang-bn.php
+++ b/language/phpmailer.lang-bn.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Bengali PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Manish Sarkar <manish.n.manish@gmail.com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP ত্রুটি: প্রমাণীকরণ করতে অক্ষম৷';
+$PHPMAILER_LANG['buggy_php']            = 'আপনার PHP সংস্করণ একটি বাগ দ্বারা প্রভাবিত হয় যার ফলে দূষিত বার্তা হতে পারে। এটি ঠিক করতে, পাঠাতে SMTP ব্যবহার করুন, আপনার php.ini এ mail.add_x_header বিকল্পটি নিষ্ক্রিয় করুন, MacOS বা Linux-এ স্যুইচ করুন, অথবা আপনার PHP সংস্করণকে 7.0.17+ বা 7.1.3+ এ পরিবর্তন করুন।';
+$PHPMAILER_LANG['connect_host']         = 'SMTP ত্রুটি: SMTP সার্ভারের সাথে সংযোগ করতে অক্ষম৷';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP ত্রুটি: ডেটা গ্রহণ করা হয়নি৷';
+$PHPMAILER_LANG['empty_message']        = 'বার্তার অংশটি খালি।';
+$PHPMAILER_LANG['encoding']             = 'অজানা এনকোডিং: ';
+$PHPMAILER_LANG['execute']              = 'নির্বাহ করতে অক্ষম: ';
+$PHPMAILER_LANG['extension_missing']    = 'এক্সটেনশন অনুপস্থিত:';
+$PHPMAILER_LANG['file_access']          = 'ফাইল অ্যাক্সেস করতে অক্ষম: ';
+$PHPMAILER_LANG['file_open']            = 'ফাইল ত্রুটি: ফাইল খুলতে অক্ষম: ';
+$PHPMAILER_LANG['from_failed']          = 'নিম্নলিখিত প্রেরকের ঠিকানা(গুলি) ব্যর্থ হয়েছে: ';
+$PHPMAILER_LANG['instantiate']          = 'মেল ফাংশনের একটি উদাহরণ তৈরি করতে অক্ষম৷';
+$PHPMAILER_LANG['invalid_address']      = 'পাঠাতে অক্ষম: অবৈধ ইমেল ঠিকানা: ';
+$PHPMAILER_LANG['invalid_header']       = 'অবৈধ হেডার নাম বা মান';
+$PHPMAILER_LANG['invalid_hostentry']    = 'অবৈধ হোস্টেন্ট্রি: ';
+$PHPMAILER_LANG['invalid_host']         = 'অবৈধ হোস্ট:';
+$PHPMAILER_LANG['mailer_not_supported'] = 'মেইলার সমর্থিত নয়।';
+$PHPMAILER_LANG['provide_address']      = 'আপনাকে অবশ্যই অন্তত একটি গন্তব্য ইমেল ঠিকানা প্রদান করতে হবে৷';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP ত্রুটি: নিম্নলিখিত গন্তব্যগুলি ব্যর্থ হয়েছে: ';
+$PHPMAILER_LANG['signing']              = 'স্বাক্ষর করতে ব্যর্থ হয়েছে: ';
+$PHPMAILER_LANG['smtp_code']            = 'SMTP কোড: ';
+$PHPMAILER_LANG['smtp_code_ex']         = 'অতিরিক্ত SMTP তথ্য:';
+$PHPMAILER_LANG['smtp_detail']          = 'বর্ণনা: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP সংযোগ() ব্যর্থ হয়েছে৷';
+$PHPMAILER_LANG['smtp_error']           = 'SMTP সার্ভার ত্রুটি: ';
+$PHPMAILER_LANG['variable_set']         = 'পরিবর্তনশীল সেট করা যায়নি: ';
+$PHPMAILER_LANG['extension_missing']    = 'অনুপস্থিত এক্সটেনশন: ';

--- a/language/phpmailer.lang-ca.php
+++ b/language/phpmailer.lang-ca.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Catalan PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Ivan <web AT microstudi DOT com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'Error SMTP: No s’ha pogut autenticar.';
+$PHPMAILER_LANG['connect_host']         = 'Error SMTP: No es pot connectar al servidor SMTP.';
+$PHPMAILER_LANG['data_not_accepted']    = 'Error SMTP: Dades no acceptades.';
+$PHPMAILER_LANG['empty_message']        = 'El cos del missatge està buit.';
+$PHPMAILER_LANG['encoding']             = 'Codificació desconeguda: ';
+$PHPMAILER_LANG['execute']              = 'No es pot executar: ';
+$PHPMAILER_LANG['file_access']          = 'No es pot accedir a l’arxiu: ';
+$PHPMAILER_LANG['file_open']            = 'Error d’Arxiu: No es pot obrir l’arxiu: ';
+$PHPMAILER_LANG['from_failed']          = 'La(s) següent(s) adreces de remitent han fallat: ';
+$PHPMAILER_LANG['instantiate']          = 'No s’ha pogut crear una instància de la funció Mail.';
+$PHPMAILER_LANG['invalid_address']      = 'Adreça d’email invalida: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' mailer no està suportat';
+$PHPMAILER_LANG['provide_address']      = 'S’ha de proveir almenys una adreça d’email com a destinatari.';
+$PHPMAILER_LANG['recipients_failed']    = 'Error SMTP: Els següents destinataris han fallat: ';
+$PHPMAILER_LANG['signing']              = 'Error al signar: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'Ha fallat el SMTP Connect().';
+$PHPMAILER_LANG['smtp_error']           = 'Error del servidor SMTP: ';
+$PHPMAILER_LANG['variable_set']         = 'No s’ha pogut establir o restablir la variable: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/language/phpmailer.lang-cs.php
+++ b/language/phpmailer.lang-cs.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Czech PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'Chyba SMTP: Autentizace selhala.';
+$PHPMAILER_LANG['connect_host']         = 'Chyba SMTP: Nelze navázat spojení se SMTP serverem.';
+$PHPMAILER_LANG['data_not_accepted']    = 'Chyba SMTP: Data nebyla přijata.';
+$PHPMAILER_LANG['empty_message']        = 'Prázdné tělo zprávy';
+$PHPMAILER_LANG['encoding']             = 'Neznámé kódování: ';
+$PHPMAILER_LANG['execute']              = 'Nelze provést: ';
+$PHPMAILER_LANG['file_access']          = 'Nelze získat přístup k souboru: ';
+$PHPMAILER_LANG['file_open']            = 'Chyba souboru: Nelze otevřít soubor pro čtení: ';
+$PHPMAILER_LANG['from_failed']          = 'Následující adresa odesílatele je nesprávná: ';
+$PHPMAILER_LANG['instantiate']          = 'Nelze vytvořit instanci emailové funkce.';
+$PHPMAILER_LANG['invalid_address']      = 'Neplatná adresa: ';
+$PHPMAILER_LANG['invalid_hostentry']    = 'Záznam hostitele je nesprávný: ';
+$PHPMAILER_LANG['invalid_host']         = 'Hostitel je nesprávný: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' mailer není podporován.';
+$PHPMAILER_LANG['provide_address']      = 'Musíte zadat alespoň jednu emailovou adresu příjemce.';
+$PHPMAILER_LANG['recipients_failed']    = 'Chyba SMTP: Následující adresy příjemců nejsou správně: ';
+$PHPMAILER_LANG['signing']              = 'Chyba přihlašování: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() selhal.';
+$PHPMAILER_LANG['smtp_error']           = 'Chyba SMTP serveru: ';
+$PHPMAILER_LANG['variable_set']         = 'Nelze nastavit nebo změnit proměnnou: ';
+$PHPMAILER_LANG['extension_missing']    = 'Chybí rozšíření: ';

--- a/language/phpmailer.lang-da.php
+++ b/language/phpmailer.lang-da.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Danish PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author John Sebastian <jms@iwb.dk>
+ * Rewrite and extension of the work by Mikael Stokkebro <info@stokkebro.dk>
+ *
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP fejl: Login mislykkedes.';
+$PHPMAILER_LANG['buggy_php']            = 'Din version af PHP er berørt af en fejl, som gør at dine beskeder muligvis vises forkert. For at rette dette kan du skifte til SMTP, slå mail.add_x_header headeren i din php.ini fil fra, skifte til MacOS eller Linux eller opgradere din version af PHP til 7.0.17+ eller 7.1.3+.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP fejl: Forbindelse til SMTP serveren kunne ikke oprettes.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP fejl: Data blev ikke accepteret.';
+$PHPMAILER_LANG['empty_message']        = 'Meddelelsen er uden indhold';
+$PHPMAILER_LANG['encoding']             = 'Ukendt encode-format: ';
+$PHPMAILER_LANG['execute']              = 'Kunne ikke afvikle: ';
+$PHPMAILER_LANG['extension_missing']    = 'Udvidelse mangler: ';
+$PHPMAILER_LANG['file_access']          = 'Kunne ikke tilgå filen: ';
+$PHPMAILER_LANG['file_open']            = 'Fil fejl: Kunne ikke åbne filen: ';
+$PHPMAILER_LANG['from_failed']          = 'Følgende afsenderadresse er forkert: ';
+$PHPMAILER_LANG['instantiate']          = 'Email funktionen kunne ikke initialiseres.';
+$PHPMAILER_LANG['invalid_address']      = 'Udgyldig adresse: ';
+$PHPMAILER_LANG['invalid_header']       = 'Ugyldig header navn eller værdi';
+$PHPMAILER_LANG['invalid_hostentry']    = 'Ugyldig hostentry: ';
+$PHPMAILER_LANG['invalid_host']         = 'Ugyldig vært: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' mailer understøttes ikke.';
+$PHPMAILER_LANG['provide_address']      = 'Indtast mindst en modtagers email adresse.';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP fejl: Følgende modtagere fejlede: ';
+$PHPMAILER_LANG['signing']              = 'Signeringsfejl: ';
+$PHPMAILER_LANG['smtp_code']            = 'SMTP kode: ';
+$PHPMAILER_LANG['smtp_code_ex']         = 'Yderligere SMTP info: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() fejlede.';
+$PHPMAILER_LANG['smtp_detail']          = 'Detalje: ';
+$PHPMAILER_LANG['smtp_error']           = 'SMTP server fejl: ';
+$PHPMAILER_LANG['variable_set']         = 'Kunne ikke definere eller nulstille variablen: ';
+$PHPMAILER_LANG['no_smtputf8']          = 'Serveren understøtter ikke SMTPUTF8 som påkrævet for at sende til Unicode adresser';
+$PHPMAILER_LANG['imap_recommended']     = 'Brug af forenklet adresseparser anbefales ikke. Installer PHP IMAP udvidelsen for fuld RFC822 parsing.';
+$PHPMAILER_LANG['deprecated_argument']  = 'Udfaset argument: ';

--- a/language/phpmailer.lang-de.php
+++ b/language/phpmailer.lang-de.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * German PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP-Fehler: Authentifizierung fehlgeschlagen.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP-Fehler: Konnte keine Verbindung zum SMTP-Host herstellen.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP-Fehler: Daten werden nicht akzeptiert.';
+$PHPMAILER_LANG['empty_message']        = 'E-Mail-Inhalt ist leer.';
+$PHPMAILER_LANG['encoding']             = 'Unbekannte Kodierung: ';
+$PHPMAILER_LANG['execute']              = 'Konnte folgenden Befehl nicht ausführen: ';
+$PHPMAILER_LANG['file_access']          = 'Zugriff auf folgende Datei fehlgeschlagen: ';
+$PHPMAILER_LANG['file_open']            = 'Dateifehler: Konnte folgende Datei nicht öffnen: ';
+$PHPMAILER_LANG['from_failed']          = 'Die folgende Absenderadresse ist nicht korrekt: ';
+$PHPMAILER_LANG['instantiate']          = 'Mail-Funktion konnte nicht initialisiert werden.';
+$PHPMAILER_LANG['invalid_address']      = 'Die Adresse ist ungültig: ';
+$PHPMAILER_LANG['invalid_hostentry']    = 'Ungültiger Hosteintrag: ';
+$PHPMAILER_LANG['invalid_host']         = 'Ungültiger Host: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' mailer wird nicht unterstützt.';
+$PHPMAILER_LANG['provide_address']      = 'Bitte geben Sie mindestens eine Empfängeradresse an.';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP-Fehler: Die folgenden Empfänger sind nicht korrekt: ';
+$PHPMAILER_LANG['signing']              = 'Fehler beim Signieren: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'Verbindung zum SMTP-Server fehlgeschlagen.';
+$PHPMAILER_LANG['smtp_error']           = 'Fehler vom SMTP-Server: ';
+$PHPMAILER_LANG['variable_set']         = 'Kann Variable nicht setzen oder zurücksetzen: ';
+$PHPMAILER_LANG['extension_missing']    = 'Fehlende Erweiterung: ';

--- a/language/phpmailer.lang-el.php
+++ b/language/phpmailer.lang-el.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Greek PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'Σφάλμα SMTP: Αδυναμία πιστοποίησης.';
+$PHPMAILER_LANG['buggy_php']            = 'Η έκδοση PHP που χρησιμοποιείτε παρουσιάζει σφάλμα που μπορεί να έχει ως αποτέλεσμα κατεστραμένα μηνύματα. Για να το διορθώσετε, αλλάξτε τον τρόπο αποστολής σε SMTP, απενεργοποιήστε την επιλογή mail.add_x_header στο αρχείο php.ini, αλλάξτε λειτουργικό σε MacOS ή Linux ή αναβαθμίστε την PHP σε έκδοση 7.0.17+ ή 7.1.3+.';
+$PHPMAILER_LANG['connect_host']         = 'Σφάλμα SMTP: Αδυναμία σύνδεσης με τον φιλοξενητή SMTP.';
+$PHPMAILER_LANG['data_not_accepted']    = 'Σφάλμα SMTP: Μη αποδεκτά δεδομένα.';
+$PHPMAILER_LANG['empty_message']        = 'Η ηλεκτρονική επιστολή δεν έχει περιεχόμενο.';
+$PHPMAILER_LANG['encoding']             = 'Άγνωστη μορφή κωδικοποίησης: ';
+$PHPMAILER_LANG['execute']              = 'Αδυναμία εκτέλεσης: ';
+$PHPMAILER_LANG['extension_missing']    = 'Απουσία επέκτασης: ';
+$PHPMAILER_LANG['file_access']          = 'Αδυναμία πρόσβασης στο αρχείο: ';
+$PHPMAILER_LANG['file_open']            = 'Σφάλμα Αρχείου: Αδυναμία ανοίγματος αρχείου: ';
+$PHPMAILER_LANG['from_failed']          = 'Η ακόλουθη διεύθυνση αποστολέα δεν είναι σωστή: ';
+$PHPMAILER_LANG['instantiate']          = 'Αδυναμία εκκίνησης συνάρτησης Mail.';
+$PHPMAILER_LANG['invalid_address']      = 'Μη έγκυρη διεύθυνση: ';
+$PHPMAILER_LANG['invalid_header']       = 'Μη έγκυρο όνομα κεφαλίδας ή τιμή';
+$PHPMAILER_LANG['invalid_hostentry']    = 'Μη έγκυρη εισαγωγή φιλοξενητή: ';
+$PHPMAILER_LANG['invalid_host']         = 'Μη έγκυρος φιλοξενητής: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' mailer δεν υποστηρίζεται.';
+$PHPMAILER_LANG['provide_address']      = 'Δώστε τουλάχιστον μια ηλεκτρονική διεύθυνση παραλήπτη.';
+$PHPMAILER_LANG['recipients_failed']    = 'Σφάλμα SMTP: Οι παρακάτω διευθύνσεις παραλήπτη δεν είναι έγκυρες: ';
+$PHPMAILER_LANG['signing']              = 'Σφάλμα υπογραφής: ';
+$PHPMAILER_LANG['smtp_code']            = 'Κώδικάς SMTP: ';
+$PHPMAILER_LANG['smtp_code_ex']         = 'Πρόσθετες πληροφορίες SMTP: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'Αποτυχία σύνδεσης SMTP.';
+$PHPMAILER_LANG['smtp_detail']          = 'Λεπτομέρεια: ';
+$PHPMAILER_LANG['smtp_error']           = 'Σφάλμα με τον διακομιστή SMTP: ';
+$PHPMAILER_LANG['variable_set']         = 'Αδυναμία ορισμού ή επαναφοράς μεταβλητής: ';

--- a/language/phpmailer.lang-eo.php
+++ b/language/phpmailer.lang-eo.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Esperanto PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Robin van der Vliet <info@robinvandervliet.com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP-eraro: Ne eblis aŭtentigi.';
+$PHPMAILER_LANG['buggy_php']            = 'Via versio de PHP estas trafita de cimo, kiu povas kaŭzi difektitajn mesaĝojn. Por ripari tion, ŝanĝu al sendado per SMTP, malŝaltu la opcion mail.add_x_header en via php.ini, ŝanĝu al MacOS aŭ Linux, aŭ ĝisdatigu vian PHP al versio 7.0.17+ aŭ 7.1.3+.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP-eraro: Ne eblis konektiĝi al la SMTP-gastiganto.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP-eraro: Datumoj ne akceptitaj.';
+$PHPMAILER_LANG['empty_message']        = 'Mesaĝokorpo malplena';
+$PHPMAILER_LANG['encoding']             = 'Nekonata kodoprezento: ';
+$PHPMAILER_LANG['execute']              = 'Ne eblis plenumi: ';
+$PHPMAILER_LANG['extension_missing']    = 'Kromprogramo mankas: ';
+$PHPMAILER_LANG['file_access']          = 'Ne eblis aliri la dosieron: ';
+$PHPMAILER_LANG['file_open']            = 'Dosiera eraro: Ne eblis malfermi la dosieron: ';
+$PHPMAILER_LANG['from_failed']          = 'La sekva(j) sendinto(j) malsukcesis: ';
+$PHPMAILER_LANG['instantiate']          = 'Ne eblis funkciigi la retpoŝtan funkcion.';
+$PHPMAILER_LANG['invalid_address']      = 'Nevalida adreso: ';
+$PHPMAILER_LANG['invalid_header']       = 'Nevalida kaplinia nomo aŭ valoro';
+$PHPMAILER_LANG['invalid_hostentry']    = 'Nevalida enigo de gastiganto: ';
+$PHPMAILER_LANG['invalid_host']         = 'Nevalida gastiganto: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' retpoŝtilo ne estas subtenata.';
+$PHPMAILER_LANG['provide_address']      = 'Vi devas provizi almenaŭ unu retpoŝtadreson de ricevonto.';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP-eraro: La sekva(j) ricevonto(j) malsukcesis: ';
+$PHPMAILER_LANG['signing']              = 'Subskriba eraro: ';
+$PHPMAILER_LANG['smtp_code']            = 'SMTP-kodo: ';
+$PHPMAILER_LANG['smtp_code_ex']         = 'Pliaj SMTP-informoj: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'La SMTP-konektiĝo malsukcesis.';
+$PHPMAILER_LANG['smtp_detail']          = 'Informoj: ';
+$PHPMAILER_LANG['smtp_error']           = 'Eraro de SMTP-servilo: ';
+$PHPMAILER_LANG['variable_set']         = 'Ne eblas agordi aŭ reagordi la variablon: ';
+$PHPMAILER_LANG['no_smtputf8']          = 'La servilo ne subtenas SMTPUTF8, kiu estas bezonata por sendi al Unicode-adresoj.';
+$PHPMAILER_LANG['imap_recommended']     = 'Uzado de la simpligita adresanalizilo ne estas rekomendita. Instalu la IMAP-kromprogramon por PHP por plena RFC822-analizado.';
+$PHPMAILER_LANG['deprecated_argument']  = 'Malrekomendita argumento: ';

--- a/language/phpmailer.lang-es.php
+++ b/language/phpmailer.lang-es.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Spanish PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Matt Sturdy <matt.sturdy@gmail.com>
+ * @author Crystopher Glodzienski Cardoso <crystopher.glodzienski@gmail.com>
+ * @author Daniel Cruz <danicruz0415@gmail.com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'Error SMTP: Imposible autentificar.';
+$PHPMAILER_LANG['buggy_php']            = 'Tu versión de PHP ha sido afectada por un bug que puede resultar en mensajes corruptos. Para arreglarlo, cambia a enviar usando SMTP, deshabilita la opción mail.add_x_header en tu php.ini, cambia a MacOS o Linux, o actualiza tu PHP a la versión 7.0.17+ o 7.1.3+.';
+$PHPMAILER_LANG['connect_host']         = 'Error SMTP: Imposible conectar al servidor SMTP.';
+$PHPMAILER_LANG['data_not_accepted']    = 'Error SMTP: Datos no aceptados.';
+$PHPMAILER_LANG['empty_message']        = 'El cuerpo del mensaje está vacío.';
+$PHPMAILER_LANG['encoding']             = 'Codificación desconocida: ';
+$PHPMAILER_LANG['execute']              = 'Imposible ejecutar: ';
+$PHPMAILER_LANG['extension_missing']    = 'Extensión faltante: ';
+$PHPMAILER_LANG['file_access']          = 'Imposible acceder al archivo: ';
+$PHPMAILER_LANG['file_open']            = 'Error de Archivo: Imposible abrir el archivo: ';
+$PHPMAILER_LANG['from_failed']          = 'La siguiente dirección de remitente falló: ';
+$PHPMAILER_LANG['instantiate']          = 'Imposible crear una instancia de la función Mail.';
+$PHPMAILER_LANG['invalid_address']      = 'Imposible enviar: dirección de email inválido: ';
+$PHPMAILER_LANG['invalid_header']       = 'Nombre o valor de encabezado no válido';
+$PHPMAILER_LANG['invalid_hostentry']    = 'Hostentry inválido: ';
+$PHPMAILER_LANG['invalid_host']         = 'Host inválido: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' mailer no está soportado.';
+$PHPMAILER_LANG['provide_address']      = 'Debe proporcionar al menos una dirección de email de destino.';
+$PHPMAILER_LANG['recipients_failed']    = 'Error SMTP: Los siguientes destinos fallaron: ';
+$PHPMAILER_LANG['signing']              = 'Error al firmar: ';
+$PHPMAILER_LANG['smtp_code']            = 'Código del servidor SMTP: ';
+$PHPMAILER_LANG['smtp_code_ex']         = 'Información adicional del servidor SMTP: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() falló.';
+$PHPMAILER_LANG['smtp_detail']          = 'Detalle: ';
+$PHPMAILER_LANG['smtp_error']           = 'Error del servidor SMTP: ';
+$PHPMAILER_LANG['variable_set']         = 'No se pudo configurar la variable: ';
+$PHPMAILER_LANG['imap_recommended']     = 'No se recomienda usar el analizador de direcciones simplificado. Instala la extensión IMAP de PHP para un análisis RFC822 más completo.';
+$PHPMAILER_LANG['deprecated_argument']  = 'Argumento obsoleto: ';

--- a/language/phpmailer.lang-et.php
+++ b/language/phpmailer.lang-et.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Estonian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Indrek Päri
+ * @author Elan Ruusamäe <glen@delfi.ee>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP Viga: Autoriseerimise viga.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP Viga: Ei õnnestunud luua ühendust SMTP serveriga.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP Viga: Vigased andmed.';
+$PHPMAILER_LANG['empty_message']        = 'Tühi kirja sisu';
+$PHPMAILER_LANG["encoding"]             = 'Tundmatu kodeering: ';
+$PHPMAILER_LANG['execute']              = 'Tegevus ebaõnnestus: ';
+$PHPMAILER_LANG['file_access']          = 'Pole piisavalt õiguseid järgneva faili avamiseks: ';
+$PHPMAILER_LANG['file_open']            = 'Faili Viga: Faili avamine ebaõnnestus: ';
+$PHPMAILER_LANG['from_failed']          = 'Järgnev saatja e-posti aadress on vigane: ';
+$PHPMAILER_LANG['instantiate']          = 'mail funktiooni käivitamine ebaõnnestus.';
+$PHPMAILER_LANG['invalid_address']      = 'Saatmine peatatud, e-posti address vigane: ';
+$PHPMAILER_LANG['provide_address']      = 'Te peate määrama vähemalt ühe saaja e-posti aadressi.';
+$PHPMAILER_LANG['mailer_not_supported'] = ' maileri tugi puudub.';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP Viga: Järgnevate saajate e-posti aadressid on vigased: ';
+$PHPMAILER_LANG["signing"]              = 'Viga allkirjastamisel: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() ebaõnnestus.';
+$PHPMAILER_LANG['smtp_error']           = 'SMTP serveri viga: ';
+$PHPMAILER_LANG['variable_set']         = 'Ei õnnestunud määrata või lähtestada muutujat: ';
+$PHPMAILER_LANG['extension_missing']    = 'Nõutud laiendus on puudu: ';

--- a/language/phpmailer.lang-fa.php
+++ b/language/phpmailer.lang-fa.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Persian/Farsi PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Ali Jazayeri <jaza.ali@gmail.com>
+ * @author Mohammad Hossein Mojtahedi <mhm5000@gmail.com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'خطای SMTP: احراز هویت با شکست مواجه شد.';
+$PHPMAILER_LANG['connect_host']         = 'خطای SMTP: اتصال به سرور SMTP برقرار نشد.';
+$PHPMAILER_LANG['data_not_accepted']    = 'خطای SMTP: داده‌ها نا‌درست هستند.';
+$PHPMAILER_LANG['empty_message']        = 'بخش متن پیام خالی است.';
+$PHPMAILER_LANG['encoding']             = 'کد‌گذاری نا‌شناخته: ';
+$PHPMAILER_LANG['execute']              = 'امکان اجرا وجود ندارد: ';
+$PHPMAILER_LANG['file_access']          = 'امکان دسترسی به فایل وجود ندارد: ';
+$PHPMAILER_LANG['file_open']            = 'خطای File: امکان بازکردن فایل وجود ندارد: ';
+$PHPMAILER_LANG['from_failed']          = 'آدرس فرستنده اشتباه است: ';
+$PHPMAILER_LANG['instantiate']          = 'امکان معرفی تابع ایمیل وجود ندارد.';
+$PHPMAILER_LANG['invalid_address']      = 'آدرس ایمیل معتبر نیست: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' mailer پشتیبانی نمی‌شود.';
+$PHPMAILER_LANG['provide_address']      = 'باید حداقل یک آدرس گیرنده وارد کنید.';
+$PHPMAILER_LANG['recipients_failed']    = 'خطای SMTP: ارسال به آدرس گیرنده با خطا مواجه شد: ';
+$PHPMAILER_LANG['signing']              = 'خطا در امضا: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'خطا در اتصال به SMTP.';
+$PHPMAILER_LANG['smtp_error']           = 'خطا در SMTP Server: ';
+$PHPMAILER_LANG['variable_set']         = 'امکان ارسال یا ارسال مجدد متغیر‌ها وجود ندارد: ';
+$PHPMAILER_LANG['extension_missing']    = 'افزونه موجود نیست: ';

--- a/language/phpmailer.lang-fi.php
+++ b/language/phpmailer.lang-fi.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Finnish PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Jyry Kuukanen
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP-virhe: käyttäjätunnistus epäonnistui.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP-virhe: yhteys palvelimeen ei onnistu.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP-virhe: data on virheellinen.';
+//$PHPMAILER_LANG['empty_message']        = 'Message body empty';
+$PHPMAILER_LANG['encoding']             = 'Tuntematon koodaustyyppi: ';
+$PHPMAILER_LANG['execute']              = 'Suoritus epäonnistui: ';
+$PHPMAILER_LANG['file_access']          = 'Seuraavaan tiedostoon ei ole oikeuksia: ';
+$PHPMAILER_LANG['file_open']            = 'Tiedostovirhe: Ei voida avata tiedostoa: ';
+$PHPMAILER_LANG['from_failed']          = 'Seuraava lähettäjän osoite on virheellinen: ';
+$PHPMAILER_LANG['instantiate']          = 'mail-funktion luonti epäonnistui.';
+//$PHPMAILER_LANG['invalid_address']      = 'Invalid address: ';
+$PHPMAILER_LANG['mailer_not_supported'] = 'postivälitintyyppiä ei tueta.';
+$PHPMAILER_LANG['provide_address']      = 'Aseta vähintään yksi vastaanottajan sähk&ouml;postiosoite.';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP-virhe: seuraava vastaanottaja osoite on virheellinen.';
+//$PHPMAILER_LANG['signing']              = 'Signing Error: ';
+//$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() failed.';
+//$PHPMAILER_LANG['smtp_error']           = 'SMTP server error: ';
+//$PHPMAILER_LANG['variable_set']         = 'Cannot set or reset variable: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/language/phpmailer.lang-fo.php
+++ b/language/phpmailer.lang-fo.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Faroese PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Dávur Sørensen <http://www.profo-webdesign.dk>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP feilur: Kundi ikki góðkenna.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP feilur: Kundi ikki knýta samband við SMTP vert.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP feilur: Data ikki góðkent.';
+//$PHPMAILER_LANG['empty_message']        = 'Message body empty';
+$PHPMAILER_LANG['encoding']             = 'Ókend encoding: ';
+$PHPMAILER_LANG['execute']              = 'Kundi ikki útføra: ';
+$PHPMAILER_LANG['file_access']          = 'Kundi ikki tilganga fílu: ';
+$PHPMAILER_LANG['file_open']            = 'Fílu feilur: Kundi ikki opna fílu: ';
+$PHPMAILER_LANG['from_failed']          = 'fylgjandi Frá/From adressa miseydnaðist: ';
+$PHPMAILER_LANG['instantiate']          = 'Kuni ikki instantiera mail funktión.';
+//$PHPMAILER_LANG['invalid_address']      = 'Invalid address: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' er ikki supporterað.';
+$PHPMAILER_LANG['provide_address']      = 'Tú skal uppgeva minst móttakara-emailadressu(r).';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP Feilur: Fylgjandi móttakarar miseydnaðust: ';
+//$PHPMAILER_LANG['signing']              = 'Signing Error: ';
+//$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() failed.';
+//$PHPMAILER_LANG['smtp_error']           = 'SMTP server error: ';
+//$PHPMAILER_LANG['variable_set']         = 'Cannot set or reset variable: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/language/phpmailer.lang-fr.php
+++ b/language/phpmailer.lang-fr.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * French PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * Some French punctuation requires a thin non-breaking space (U+202F) character before it,
+ * for example before a colon or exclamation mark.
+ * There is one of these characters between these quotes: " "
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'Erreur SMTP : échec de l’authentification.';
+$PHPMAILER_LANG['buggy_php']            = 'Votre version de PHP est affectée par un bug qui peut entraîner des messages corrompus. Pour résoudre ce problème, passez à l’envoi par SMTP, désactivez l’option mail.add_x_header dans le fichier php.ini, passez à MacOS ou Linux, ou passez PHP à la version 7.0.17+ ou 7.1.3+.';
+$PHPMAILER_LANG['connect_host']         = 'Erreur SMTP : impossible de se connecter au serveur SMTP.';
+$PHPMAILER_LANG['data_not_accepted']    = 'Erreur SMTP : données incorrectes.';
+$PHPMAILER_LANG['empty_message']        = 'Corps du message vide.';
+$PHPMAILER_LANG['encoding']             = 'Encodage inconnu : ';
+$PHPMAILER_LANG['execute']              = 'Impossible de lancer l’exécution : ';
+$PHPMAILER_LANG['extension_missing']    = 'Extension manquante : ';
+$PHPMAILER_LANG['file_access']          = 'Impossible d’accéder au fichier : ';
+$PHPMAILER_LANG['file_open']            = 'Ouverture du fichier impossible : ';
+$PHPMAILER_LANG['from_failed']          = 'L’adresse d’expéditeur suivante a échoué : ';
+$PHPMAILER_LANG['instantiate']          = 'Impossible d’instancier la fonction mail.';
+$PHPMAILER_LANG['invalid_address']      = 'Adresse courriel non valide : ';
+$PHPMAILER_LANG['invalid_header']       = 'Nom ou valeur de l’en-tête non valide';
+$PHPMAILER_LANG['invalid_hostentry']    = 'Entrée d’hôte non valide : ';
+$PHPMAILER_LANG['invalid_host']         = 'Hôte non valide : ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' client de messagerie non supporté.';
+$PHPMAILER_LANG['provide_address']      = 'Vous devez fournir au moins une adresse de destinataire.';
+$PHPMAILER_LANG['recipients_failed']    = 'Erreur SMTP : les destinataires suivants ont échoué : ';
+$PHPMAILER_LANG['signing']              = 'Erreur de signature : ';
+$PHPMAILER_LANG['smtp_code']            = 'Code SMTP : ';
+$PHPMAILER_LANG['smtp_code_ex']         = 'Informations supplémentaires SMTP : ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'La fonction SMTP connect() a échoué.';
+$PHPMAILER_LANG['smtp_detail']          = 'Détails : ';
+$PHPMAILER_LANG['smtp_error']           = 'Erreur du serveur SMTP : ';
+$PHPMAILER_LANG['variable_set']         = 'Impossible d’initialiser ou de réinitialiser une variable : ';

--- a/language/phpmailer.lang-gl.php
+++ b/language/phpmailer.lang-gl.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Galician PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author by Donato Rouco <donatorouco@gmail.com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'Erro SMTP: Non puido ser autentificado.';
+$PHPMAILER_LANG['connect_host']         = 'Erro SMTP: Non puido conectar co servidor SMTP.';
+$PHPMAILER_LANG['data_not_accepted']    = 'Erro SMTP: Datos non aceptados.';
+$PHPMAILER_LANG['empty_message']        = 'Corpo da mensaxe vacía';
+$PHPMAILER_LANG['encoding']             = 'Codificación descoñecida: ';
+$PHPMAILER_LANG['execute']              = 'Non puido ser executado: ';
+$PHPMAILER_LANG['file_access']          = 'Nob puido acceder ó arquivo: ';
+$PHPMAILER_LANG['file_open']            = 'Erro de Arquivo: No puido abrir o arquivo: ';
+$PHPMAILER_LANG['from_failed']          = 'A(s) seguinte(s) dirección(s) de remitente(s) deron erro: ';
+$PHPMAILER_LANG['instantiate']          = 'Non puido crear unha instancia da función Mail.';
+$PHPMAILER_LANG['invalid_address']      = 'Non puido envia-lo correo: dirección de email inválida: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' mailer non está soportado.';
+$PHPMAILER_LANG['provide_address']      = 'Debe engadir polo menos unha dirección de email coma destino.';
+$PHPMAILER_LANG['recipients_failed']    = 'Erro SMTP: Os seguintes destinos fallaron: ';
+$PHPMAILER_LANG['signing']              = 'Erro ó firmar: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() fallou.';
+$PHPMAILER_LANG['smtp_error']           = 'Erro do servidor SMTP: ';
+$PHPMAILER_LANG['variable_set']         = 'Non puidemos axustar ou reaxustar a variábel: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/language/phpmailer.lang-he.php
+++ b/language/phpmailer.lang-he.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Hebrew PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Ronny Sherer <ronny@hoojima.com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'שגיאת SMTP: פעולת האימות נכשלה.';
+$PHPMAILER_LANG['connect_host']         = 'שגיאת SMTP: לא הצלחתי להתחבר לשרת SMTP.';
+$PHPMAILER_LANG['data_not_accepted']    = 'שגיאת SMTP: מידע לא התקבל.';
+$PHPMAILER_LANG['empty_message']        = 'גוף ההודעה ריק';
+$PHPMAILER_LANG['invalid_address']      = 'כתובת שגויה: ';
+$PHPMAILER_LANG['encoding']             = 'קידוד לא מוכר: ';
+$PHPMAILER_LANG['execute']              = 'לא הצלחתי להפעיל את: ';
+$PHPMAILER_LANG['file_access']          = 'לא ניתן לגשת לקובץ: ';
+$PHPMAILER_LANG['file_open']            = 'שגיאת קובץ: לא ניתן לגשת לקובץ: ';
+$PHPMAILER_LANG['from_failed']          = 'כתובות הנמענים הבאות נכשלו: ';
+$PHPMAILER_LANG['instantiate']          = 'לא הצלחתי להפעיל את פונקציית המייל.';
+$PHPMAILER_LANG['mailer_not_supported'] = ' אינה נתמכת.';
+$PHPMAILER_LANG['provide_address']      = 'חובה לספק לפחות כתובת אחת של מקבל המייל.';
+$PHPMAILER_LANG['recipients_failed']    = 'שגיאת SMTP: הנמענים הבאים נכשלו: ';
+$PHPMAILER_LANG['signing']              = 'שגיאת חתימה: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() failed.';
+$PHPMAILER_LANG['smtp_error']           = 'שגיאת שרת SMTP: ';
+$PHPMAILER_LANG['variable_set']         = 'לא ניתן לקבוע או לשנות את המשתנה: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/language/phpmailer.lang-hi.php
+++ b/language/phpmailer.lang-hi.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Hindi PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Yash Karanke <mr.karanke@gmail.com>
+ * Rewrite and extension of the work by Jayanti Suthar <suthar.jayanti93@gmail.com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP त्रुटि: प्रामाणिकता की जांच नहीं हो सका। ';
+$PHPMAILER_LANG['buggy_php']            = 'PHP का आपका संस्करण एक बग से प्रभावित है जिसके परिणामस्वरूप संदेश दूषित हो सकते हैं. इसे ठीक करने हेतु, भेजने के लिए SMTP का उपयोग करे, अपने php.ini में mail.add_x_header विकल्प को अक्षम करें, MacOS या Linux पर जाए, या अपने PHP संस्करण को 7.0.17+ या 7.1.3+ बदले.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP त्रुटि: SMTP सर्वर से कनेक्ट नहीं हो सका। ';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP त्रुटि: डेटा स्वीकार नहीं किया जाता है। ';
+$PHPMAILER_LANG['empty_message']        = 'संदेश खाली है। ';
+$PHPMAILER_LANG['encoding']             = 'अज्ञात एन्कोडिंग प्रकार। ';
+$PHPMAILER_LANG['execute']              = 'आदेश को निष्पादित करने में विफल। ';
+$PHPMAILER_LANG['extension_missing']    = 'एक्सटेन्षन गायब है: ';
+$PHPMAILER_LANG['file_access']          = 'फ़ाइल उपलब्ध नहीं है। ';
+$PHPMAILER_LANG['file_open']            = 'फ़ाइल त्रुटि: फाइल को खोला नहीं जा सका। ';
+$PHPMAILER_LANG['from_failed']          = 'प्रेषक का पता गलत है। ';
+$PHPMAILER_LANG['instantiate']          = 'मेल फ़ंक्शन कॉल नहीं कर सकता है।';
+$PHPMAILER_LANG['invalid_address']      = 'पता गलत है। ';
+$PHPMAILER_LANG['invalid_header']       = 'अमान्य हेडर नाम या मान';
+$PHPMAILER_LANG['invalid_hostentry']    = 'अमान्य hostentry: ';
+$PHPMAILER_LANG['invalid_host']         = 'अमान्य होस्ट: ';
+$PHPMAILER_LANG['mailer_not_supported'] = 'मेल सर्वर के साथ काम नहीं करता है। ';
+$PHPMAILER_LANG['provide_address']      = 'आपको कम से कम एक प्राप्तकर्ता का ई-मेल पता प्रदान करना होगा।';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP त्रुटि: निम्न प्राप्तकर्ताओं को पते भेजने में विफल। ';
+$PHPMAILER_LANG['signing']              = 'साइनअप त्रुटि: ';
+$PHPMAILER_LANG['smtp_code']            = 'SMTP कोड: ';
+$PHPMAILER_LANG['smtp_code_ex']         = 'अतिरिक्त SMTP जानकारी: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP का connect () फ़ंक्शन विफल हुआ। ';
+$PHPMAILER_LANG['smtp_detail']          = 'विवरण: ';
+$PHPMAILER_LANG['smtp_error']           = 'SMTP सर्वर त्रुटि। ';
+$PHPMAILER_LANG['variable_set']         = 'चर को बना या संशोधित नहीं किया जा सकता। ';

--- a/language/phpmailer.lang-hr.php
+++ b/language/phpmailer.lang-hr.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Croatian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Hrvoj3e <hrvoj3e@gmail.com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP Greška: Neuspjela autentikacija.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP Greška: Ne mogu se spojiti na SMTP poslužitelj.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP Greška: Podatci nisu prihvaćeni.';
+$PHPMAILER_LANG['empty_message']        = 'Sadržaj poruke je prazan.';
+$PHPMAILER_LANG['encoding']             = 'Nepoznati encoding: ';
+$PHPMAILER_LANG['execute']              = 'Nije moguće izvršiti naredbu: ';
+$PHPMAILER_LANG['file_access']          = 'Nije moguće pristupiti datoteci: ';
+$PHPMAILER_LANG['file_open']            = 'Nije moguće otvoriti datoteku: ';
+$PHPMAILER_LANG['from_failed']          = 'SMTP Greška: Slanje s navedenih e-mail adresa nije uspjelo: ';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP Greška: Slanje na navedenih e-mail adresa nije uspjelo: ';
+$PHPMAILER_LANG['instantiate']          = 'Ne mogu pokrenuti mail funkcionalnost.';
+$PHPMAILER_LANG['invalid_address']      = 'E-mail nije poslan. Neispravna e-mail adresa: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' mailer nije podržan.';
+$PHPMAILER_LANG['provide_address']      = 'Definirajte barem jednu adresu primatelja.';
+$PHPMAILER_LANG['signing']              = 'Greška prilikom prijave: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'Spajanje na SMTP poslužitelj nije uspjelo.';
+$PHPMAILER_LANG['smtp_error']           = 'Greška SMTP poslužitelja: ';
+$PHPMAILER_LANG['variable_set']         = 'Ne mogu postaviti varijablu niti ju vratiti nazad: ';
+$PHPMAILER_LANG['extension_missing']    = 'Nedostaje proširenje: ';

--- a/language/phpmailer.lang-hu.php
+++ b/language/phpmailer.lang-hu.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Hungarian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author @dominicus-75
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP hiba: az azonosítás sikertelen.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP hiba: nem lehet kapcsolódni az SMTP-szerverhez.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP hiba: adatok visszautasítva.';
+$PHPMAILER_LANG['empty_message']        = 'Üres az üzenettörzs.';
+$PHPMAILER_LANG['encoding']             = 'Ismeretlen kódolás: ';
+$PHPMAILER_LANG['execute']              = 'Nem lehet végrehajtani: ';
+$PHPMAILER_LANG['file_access']          = 'A következő fájl nem elérhető: ';
+$PHPMAILER_LANG['file_open']            = 'Fájl hiba: a következő fájlt nem lehet megnyitni: ';
+$PHPMAILER_LANG['from_failed']          = 'A feladóként megadott következő cím hibás: ';
+$PHPMAILER_LANG['instantiate']          = 'A PHP mail() függvényt nem sikerült végrehajtani.';
+$PHPMAILER_LANG['invalid_address']      = 'Érvénytelen cím: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' a mailer-osztály nem támogatott.';
+$PHPMAILER_LANG['provide_address']      = 'Legalább egy címzettet fel kell tüntetni.';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP hiba: a címzettként megadott következő címek hibásak: ';
+$PHPMAILER_LANG['signing']              = 'Hibás aláírás: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'Hiba az SMTP-kapcsolatban.';
+$PHPMAILER_LANG['smtp_error']           = 'SMTP-szerver hiba: ';
+$PHPMAILER_LANG['variable_set']         = 'A következő változók beállítása nem sikerült: ';
+$PHPMAILER_LANG['extension_missing']    = 'Bővítmény hiányzik: ';

--- a/language/phpmailer.lang-hy.php
+++ b/language/phpmailer.lang-hy.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Armenian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Hrayr Grigoryan <hrayr@bits.am>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP -ի սխալ: չհաջողվեց ստուգել իսկությունը.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP -ի սխալ: չհաջողվեց կապ հաստատել SMTP սերվերի հետ.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP -ի սխալ: տվյալները ընդունված չեն.';
+$PHPMAILER_LANG['empty_message']        = 'Հաղորդագրությունը դատարկ է';
+$PHPMAILER_LANG['encoding']             = 'Կոդավորման անհայտ տեսակ: ';
+$PHPMAILER_LANG['execute']              = 'Չհաջողվեց իրականացնել հրամանը: ';
+$PHPMAILER_LANG['file_access']          = 'Ֆայլը հասանելի չէ: ';
+$PHPMAILER_LANG['file_open']            = 'Ֆայլի սխալ: ֆայլը չհաջողվեց բացել: ';
+$PHPMAILER_LANG['from_failed']          = 'Ուղարկողի հետևյալ հասցեն սխալ է: ';
+$PHPMAILER_LANG['instantiate']          = 'Հնարավոր չէ կանչել mail ֆունկցիան.';
+$PHPMAILER_LANG['invalid_address']      = 'Հասցեն սխալ է: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' փոստային սերվերի հետ չի աշխատում.';
+$PHPMAILER_LANG['provide_address']      = 'Անհրաժեշտ է տրամադրել գոնե մեկ ստացողի e-mail հասցե.';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP -ի սխալ: չի հաջողվել ուղարկել հետևյալ ստացողների հասցեներին: ';
+$PHPMAILER_LANG['signing']              = 'Ստորագրման սխալ: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP -ի connect() ֆունկցիան չի հաջողվել';
+$PHPMAILER_LANG['smtp_error']           = 'SMTP սերվերի սխալ: ';
+$PHPMAILER_LANG['variable_set']         = 'Չի հաջողվում ստեղծել կամ վերափոխել փոփոխականը: ';
+$PHPMAILER_LANG['extension_missing']    = 'Հավելվածը բացակայում է: ';

--- a/language/phpmailer.lang-id.php
+++ b/language/phpmailer.lang-id.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Indonesian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Cecep Prawiro <cecep.prawiro@gmail.com>
+ * @author @januridp
+ * @author Ian Mustafa <mail@ianmustafa.com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'Kesalahan SMTP: Tidak dapat mengotentikasi.';
+$PHPMAILER_LANG['connect_host']         = 'Kesalahan SMTP: Tidak dapat terhubung ke host SMTP.';
+$PHPMAILER_LANG['data_not_accepted']    = 'Kesalahan SMTP: Data tidak diterima.';
+$PHPMAILER_LANG['empty_message']        = 'Isi pesan kosong';
+$PHPMAILER_LANG['encoding']             = 'Pengkodean karakter tidak dikenali: ';
+$PHPMAILER_LANG['execute']              = 'Tidak dapat menjalankan proses: ';
+$PHPMAILER_LANG['file_access']          = 'Tidak dapat mengakses berkas: ';
+$PHPMAILER_LANG['file_open']            = 'Kesalahan Berkas: Berkas tidak dapat dibuka: ';
+$PHPMAILER_LANG['from_failed']          = 'Alamat pengirim berikut mengakibatkan kesalahan: ';
+$PHPMAILER_LANG['instantiate']          = 'Tidak dapat menginisialisasi fungsi surel.';
+$PHPMAILER_LANG['invalid_address']      = 'Gagal terkirim, alamat surel tidak sesuai: ';
+$PHPMAILER_LANG['invalid_hostentry']    = 'Gagal terkirim, entri host tidak sesuai: ';
+$PHPMAILER_LANG['invalid_host']         = 'Gagal terkirim, host tidak sesuai: ';
+$PHPMAILER_LANG['provide_address']      = 'Harus tersedia minimal satu alamat tujuan';
+$PHPMAILER_LANG['mailer_not_supported'] = ' mailer tidak didukung';
+$PHPMAILER_LANG['recipients_failed']    = 'Kesalahan SMTP: Alamat tujuan berikut menyebabkan kesalahan: ';
+$PHPMAILER_LANG['signing']              = 'Kesalahan dalam penandatangan SSL: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() gagal.';
+$PHPMAILER_LANG['smtp_error']           = 'Kesalahan pada pelayan SMTP: ';
+$PHPMAILER_LANG['variable_set']         = 'Tidak dapat mengatur atau mengatur ulang variabel: ';
+$PHPMAILER_LANG['extension_missing']    = 'Ekstensi PHP tidak tersedia: ';

--- a/language/phpmailer.lang-it.php
+++ b/language/phpmailer.lang-it.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Italian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Ilias Bartolini <brain79@inwind.it>
+ * @author Stefano Sabatini <sabas88@gmail.com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP Error: Impossibile autenticarsi.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP Error: Impossibile connettersi all\'host SMTP.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP Error: Dati non accettati dal server.';
+$PHPMAILER_LANG['empty_message']        = 'Il corpo del messaggio è vuoto';
+$PHPMAILER_LANG['encoding']             = 'Codifica dei caratteri sconosciuta: ';
+$PHPMAILER_LANG['execute']              = 'Impossibile eseguire l\'operazione: ';
+$PHPMAILER_LANG['file_access']          = 'Impossibile accedere al file: ';
+$PHPMAILER_LANG['file_open']            = 'File Error: Impossibile aprire il file: ';
+$PHPMAILER_LANG['from_failed']          = 'I seguenti indirizzi mittenti hanno generato errore: ';
+$PHPMAILER_LANG['instantiate']          = 'Impossibile istanziare la funzione mail';
+$PHPMAILER_LANG['invalid_address']      = 'Impossibile inviare, l\'indirizzo email non è valido: ';
+$PHPMAILER_LANG['provide_address']      = 'Deve essere fornito almeno un indirizzo ricevente';
+$PHPMAILER_LANG['mailer_not_supported'] = 'Mailer non supportato';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP Error: I seguenti indirizzi destinatari hanno generato un errore: ';
+$PHPMAILER_LANG['signing']              = 'Errore nella firma: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() fallita.';
+$PHPMAILER_LANG['smtp_error']           = 'Errore del server SMTP: ';
+$PHPMAILER_LANG['variable_set']         = 'Impossibile impostare o resettare la variabile: ';
+$PHPMAILER_LANG['extension_missing']    = 'Estensione mancante: ';

--- a/language/phpmailer.lang-ja.php
+++ b/language/phpmailer.lang-ja.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Japanese PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Mitsuhiro Yoshida <https://mitstek.com>
+ * @author Yoshi Sakai <http://bluemooninc.jp/>
+ * @author Arisophy <https://github.com/arisophy/>
+ * @author ARAKI Musashi <https://github.com/arakim/>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTPエラー: 認証できませんでした。';
+$PHPMAILER_LANG['buggy_php']            = 'ご利用のバージョンのPHPには不具合があり、メッセージが破損するおそれがあります。問題の解決は以下のいずれかを行ってください。SMTPでの送信に切り替える。php.iniのmail.add_x_headerをoffにする。MacOSまたはLinuxに切り替える。PHPバージョン7.0.17以降または7.1.3以降にアップグレードする。';
+$PHPMAILER_LANG['connect_host']         = 'SMTPエラー: SMTPホストに接続できませんでした。';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTPエラー: データが受け付けられませんでした。';
+$PHPMAILER_LANG['empty_message']        = 'メール本文が空です。';
+$PHPMAILER_LANG['encoding']             = '不明なエンコーディング: ';
+$PHPMAILER_LANG['execute']              = '実行できませんでした: ';
+$PHPMAILER_LANG['extension_missing']    = '拡張機能が見つかりません: ';
+$PHPMAILER_LANG['file_access']          = 'ファイルにアクセスできません: ';
+$PHPMAILER_LANG['file_open']            = 'ファイルエラー: ファイルを開けません: ';
+$PHPMAILER_LANG['from_failed']          = 'Fromアドレスを登録する際にエラーが発生しました: ';
+$PHPMAILER_LANG['instantiate']          = 'メール関数が正常に動作しませんでした。';
+$PHPMAILER_LANG['invalid_address']      = '不正なメールアドレス: ';
+$PHPMAILER_LANG['invalid_header']       = '不正なヘッダー名またはその内容';
+$PHPMAILER_LANG['invalid_hostentry']    = '不正なホストエントリー: ';
+$PHPMAILER_LANG['invalid_host']         = '不正なホスト: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' メーラーがサポートされていません。';
+$PHPMAILER_LANG['provide_address']      = '少なくとも1つメールアドレスを 指定する必要があります。';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTPエラー: 次の受信者アドレスに 間違いがあります: ';
+$PHPMAILER_LANG['signing']              = '署名エラー: ';
+$PHPMAILER_LANG['smtp_code']            = 'SMTPコード: ';
+$PHPMAILER_LANG['smtp_code_ex']         = 'SMTP追加情報: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP接続に失敗しました。';
+$PHPMAILER_LANG['smtp_detail']          = '詳細: ';
+$PHPMAILER_LANG['smtp_error']           = 'SMTPサーバーエラー: ';
+$PHPMAILER_LANG['variable_set']         = '変数が存在しません: ';

--- a/language/phpmailer.lang-ka.php
+++ b/language/phpmailer.lang-ka.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Georgian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Avtandil Kikabidze aka LONGMAN <akalongman@gmail.com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP შეცდომა: ავტორიზაცია შეუძლებელია.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP შეცდომა: SMTP სერვერთან დაკავშირება შეუძლებელია.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP შეცდომა: მონაცემები არ იქნა მიღებული.';
+$PHPMAILER_LANG['encoding']             = 'კოდირების უცნობი ტიპი: ';
+$PHPMAILER_LANG['execute']              = 'შეუძლებელია შემდეგი ბრძანების შესრულება: ';
+$PHPMAILER_LANG['file_access']          = 'შეუძლებელია წვდომა ფაილთან: ';
+$PHPMAILER_LANG['file_open']            = 'ფაილური სისტემის შეცდომა: არ იხსნება ფაილი: ';
+$PHPMAILER_LANG['from_failed']          = 'გამგზავნის არასწორი მისამართი: ';
+$PHPMAILER_LANG['instantiate']          = 'mail ფუნქციის გაშვება ვერ ხერხდება.';
+$PHPMAILER_LANG['provide_address']      = 'გთხოვთ მიუთითოთ ერთი ადრესატის e-mail მისამართი მაინც.';
+$PHPMAILER_LANG['mailer_not_supported'] = ' - საფოსტო სერვერის მხარდაჭერა არ არის.';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP შეცდომა: შემდეგ მისამართებზე გაგზავნა ვერ მოხერხდა: ';
+$PHPMAILER_LANG['empty_message']        = 'შეტყობინება ცარიელია';
+$PHPMAILER_LANG['invalid_address']      = 'არ გაიგზავნა, e-mail მისამართის არასწორი ფორმატი: ';
+$PHPMAILER_LANG['signing']              = 'ხელმოწერის შეცდომა: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'შეცდომა SMTP სერვერთან დაკავშირებისას';
+$PHPMAILER_LANG['smtp_error']           = 'SMTP სერვერის შეცდომა: ';
+$PHPMAILER_LANG['variable_set']         = 'შეუძლებელია შემდეგი ცვლადის შექმნა ან შეცვლა: ';
+$PHPMAILER_LANG['extension_missing']    = 'ბიბლიოთეკა არ არსებობს: ';

--- a/language/phpmailer.lang-ko.php
+++ b/language/phpmailer.lang-ko.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Korean PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author ChalkPE <amato0617@gmail.com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP 오류: 인증할 수 없습니다.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP 오류: SMTP 호스트에 접속할 수 없습니다.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP 오류: 데이터가 받아들여지지 않았습니다.';
+$PHPMAILER_LANG['empty_message']        = '메세지 내용이 없습니다';
+$PHPMAILER_LANG['encoding']             = '알 수 없는 인코딩: ';
+$PHPMAILER_LANG['execute']              = '실행 불가: ';
+$PHPMAILER_LANG['file_access']          = '파일 접근 불가: ';
+$PHPMAILER_LANG['file_open']            = '파일 오류: 파일을 열 수 없습니다: ';
+$PHPMAILER_LANG['from_failed']          = '다음 From 주소에서 오류가 발생했습니다: ';
+$PHPMAILER_LANG['instantiate']          = 'mail 함수를 인스턴스화할 수 없습니다';
+$PHPMAILER_LANG['invalid_address']      = '잘못된 주소: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' 메일러는 지원되지 않습니다.';
+$PHPMAILER_LANG['provide_address']      = '적어도 한 개 이상의 수신자 메일 주소를 제공해야 합니다.';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP 오류: 다음 수신자에서 오류가 발생했습니다: ';
+$PHPMAILER_LANG['signing']              = '서명 오류: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP 연결을 실패하였습니다.';
+$PHPMAILER_LANG['smtp_error']           = 'SMTP 서버 오류: ';
+$PHPMAILER_LANG['variable_set']         = '변수 설정 및 초기화 불가: ';
+$PHPMAILER_LANG['extension_missing']    = '확장자 없음: ';

--- a/language/phpmailer.lang-ku.php
+++ b/language/phpmailer.lang-ku.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Kurdish (Sorani) PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Halo Salman <halo@home4t.com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'هەڵەی SMTP : نەتوانرا کۆدەکە پشتڕاست بکرێتەوە ';
+$PHPMAILER_LANG['connect_host']         = 'هەڵەی SMTP: نەتوانرا پەیوەندی بە سێرڤەرەوە بکات SMTP.';
+$PHPMAILER_LANG['data_not_accepted']    = 'هەڵەی SMTP: ئەو زانیاریانە قبوڵ نەکرا.';
+$PHPMAILER_LANG['empty_message']        = 'پەیامەکە بەتاڵە';
+$PHPMAILER_LANG['encoding']             = 'کۆدکردنی نەزانراو : ';
+$PHPMAILER_LANG['execute']              = 'ناتوانرێت جێبەجێ بکرێت: ';
+$PHPMAILER_LANG['file_access']          = 'ناتوانرێت دەستت بگات بە فایلەکە: ';
+$PHPMAILER_LANG['file_open']            = 'هەڵەی پەڕگە(فایل): ناتوانرێت بکرێتەوە: ';
+$PHPMAILER_LANG['from_failed']          = 'هەڵە لە ئاستی ناونیشانی نێرەر: ';
+$PHPMAILER_LANG['instantiate']          = 'ناتوانرێت خزمەتگوزاری پۆستە پێشکەش بکرێت.';
+$PHPMAILER_LANG['invalid_address']      = 'نەتوانرا بنێردرێت ، چونکە ناونیشانی ئیمەیڵەکە نادروستە: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' مەیلەر پشتگیری ناکات';
+$PHPMAILER_LANG['provide_address']      = 'دەبێت ناونیشانی ئیمەیڵی لانیکەم یەک وەرگر دابین بکرێت.';
+$PHPMAILER_LANG['recipients_failed']    = ' هەڵەی SMTP: ئەم هەڵانەی خوارەوەشکستی هێنا لە ناردن بۆ هەردووکیان: ';
+$PHPMAILER_LANG['signing']              = 'هەڵەی واژۆ: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect()پەیوەندی شکستی هێنا .';
+$PHPMAILER_LANG['smtp_error']           = 'هەڵەی ئاستی سێرڤەری SMTP: ';
+$PHPMAILER_LANG['variable_set']         = 'ناتوانرێت بیگۆڕیت یان دوبارە بینێریتەوە: ';
+$PHPMAILER_LANG['extension_missing']    = 'درێژکراوە نەماوە: ';

--- a/language/phpmailer.lang-lt.php
+++ b/language/phpmailer.lang-lt.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Lithuanian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Dainius Kaupaitis <dk@sum.lt>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP klaida: autentifikacija nepavyko.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP klaida: nepavyksta prisijungti prie SMTP stoties.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP klaida: duomenys nepriimti.';
+$PHPMAILER_LANG['empty_message']        = 'Laiško turinys tuščias';
+$PHPMAILER_LANG['encoding']             = 'Neatpažinta koduotė: ';
+$PHPMAILER_LANG['execute']              = 'Nepavyko įvykdyti komandos: ';
+$PHPMAILER_LANG['file_access']          = 'Byla nepasiekiama: ';
+$PHPMAILER_LANG['file_open']            = 'Bylos klaida: Nepavyksta atidaryti: ';
+$PHPMAILER_LANG['from_failed']          = 'Neteisingas siuntėjo adresas: ';
+$PHPMAILER_LANG['instantiate']          = 'Nepavyko paleisti mail funkcijos.';
+$PHPMAILER_LANG['invalid_address']      = 'Neteisingas adresas: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' pašto stotis nepalaikoma.';
+$PHPMAILER_LANG['provide_address']      = 'Nurodykite bent vieną gavėjo adresą.';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP klaida: nepavyko išsiųsti šiems gavėjams: ';
+$PHPMAILER_LANG['signing']              = 'Prisijungimo klaida: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP susijungimo klaida';
+$PHPMAILER_LANG['smtp_error']           = 'SMTP stoties klaida: ';
+$PHPMAILER_LANG['variable_set']         = 'Nepavyko priskirti reikšmės kintamajam: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/language/phpmailer.lang-lv.php
+++ b/language/phpmailer.lang-lv.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Latvian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Eduards M. <e@npd.lv>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP kļūda: Autorizācija neizdevās.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP Kļūda: Nevar izveidot savienojumu ar SMTP serveri.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP Kļūda: Nepieņem informāciju.';
+$PHPMAILER_LANG['empty_message']        = 'Ziņojuma teksts ir tukšs';
+$PHPMAILER_LANG['encoding']             = 'Neatpazīts kodējums: ';
+$PHPMAILER_LANG['execute']              = 'Neizdevās izpildīt komandu: ';
+$PHPMAILER_LANG['file_access']          = 'Fails nav pieejams: ';
+$PHPMAILER_LANG['file_open']            = 'Faila kļūda: Nevar atvērt failu: ';
+$PHPMAILER_LANG['from_failed']          = 'Nepareiza sūtītāja adrese: ';
+$PHPMAILER_LANG['instantiate']          = 'Nevar palaist sūtīšanas funkciju.';
+$PHPMAILER_LANG['invalid_address']      = 'Nepareiza adrese: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' sūtītājs netiek atbalstīts.';
+$PHPMAILER_LANG['provide_address']      = 'Lūdzu, norādiet vismaz vienu adresātu.';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP kļūda: neizdevās nosūtīt šādiem saņēmējiem: ';
+$PHPMAILER_LANG['signing']              = 'Autorizācijas kļūda: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP savienojuma kļūda';
+$PHPMAILER_LANG['smtp_error']           = 'SMTP servera kļūda: ';
+$PHPMAILER_LANG['variable_set']         = 'Nevar piešķirt mainīgā vērtību: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/language/phpmailer.lang-mg.php
+++ b/language/phpmailer.lang-mg.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Malagasy PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Hackinet <piyushjha8164@gmail.com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'Hadisoana SMTP: Tsy nahomby ny fanamarinana.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP Error: Tsy afaka mampifandray amin\'ny mpampiantrano SMTP.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP diso: tsy voarakitra ny angona.';
+$PHPMAILER_LANG['empty_message']        = 'Tsy misy ny votoaty mailaka.';
+$PHPMAILER_LANG['encoding']             = 'Tsy fantatra encoding: ';
+$PHPMAILER_LANG['execute']              = 'Tsy afaka manatanteraka ity baiko manaraka ity: ';
+$PHPMAILER_LANG['file_access']          = 'Tsy nahomby ny fidirana amin\'ity rakitra ity: ';
+$PHPMAILER_LANG['file_open']            = 'Hadisoana diso: Tsy afaka nanokatra ity file manaraka ity: ';
+$PHPMAILER_LANG['from_failed']          = 'Ny adiresy iraka manaraka dia diso: ';
+$PHPMAILER_LANG['instantiate']          = 'Tsy afaka nanomboka ny hetsika mail.';
+$PHPMAILER_LANG['invalid_address']      = 'Tsy mety ny adiresy: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' mailer tsy manohana.';
+$PHPMAILER_LANG['provide_address']      = 'Alefaso azafady iray adiresy iray farafahakeliny.';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP Error: Tsy mety ireo mpanaraka ireto: ';
+$PHPMAILER_LANG['signing']              = 'Error nandritra ny sonia:';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'Tsy nahomby ny fifandraisana tamin\'ny server SMTP.';
+$PHPMAILER_LANG['smtp_error']           = 'Fahadisoana tamin\'ny server SMTP: ';
+$PHPMAILER_LANG['variable_set']         = 'Tsy azo atao ny mametraka na mamerina ny variable: ';
+$PHPMAILER_LANG['extension_missing']    = 'Tsy hita ny ampahany: ';

--- a/language/phpmailer.lang-mn.php
+++ b/language/phpmailer.lang-mn.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Mongolian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author @wispas
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'Алдаа SMTP: Холбогдож чадсангүй.';
+$PHPMAILER_LANG['connect_host']         = 'Алдаа SMTP: SMTP- сервертэй холбогдож болохгүй байна.';
+$PHPMAILER_LANG['data_not_accepted']    = 'Алдаа SMTP: зөвшөөрөгдсөнгүй.';
+$PHPMAILER_LANG['encoding']             = 'Тодорхойгүй кодчилол: ';
+$PHPMAILER_LANG['execute']              = 'Коммандыг гүйцэтгэх боломжгүй байна: ';
+$PHPMAILER_LANG['file_access']          = 'Файлд хандах боломжгүй байна: ';
+$PHPMAILER_LANG['file_open']            = 'Файлын алдаа: файлыг нээх боломжгүй байна: ';
+$PHPMAILER_LANG['from_failed']          = 'Илгээгчийн хаяг буруу байна: ';
+$PHPMAILER_LANG['instantiate']          = 'Mail () функцийг ажиллуулах боломжгүй байна.';
+$PHPMAILER_LANG['provide_address']      = 'Хүлээн авагчийн имэйл хаягийг оруулна уу.';
+$PHPMAILER_LANG['mailer_not_supported'] = ' — мэйл серверийг дэмжсэнгүй.';
+$PHPMAILER_LANG['recipients_failed']    = 'Алдаа SMTP: ийм хаягийг илгээж чадсангүй: ';
+$PHPMAILER_LANG['empty_message']        = 'Хоосон мессэж';
+$PHPMAILER_LANG['invalid_address']      = 'И-Мэйл буруу форматтай тул илгээх боломжгүй: ';
+$PHPMAILER_LANG['signing']              = 'Гарын үсгийн алдаа: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP сервертэй холбогдоход алдаа гарлаа';
+$PHPMAILER_LANG['smtp_error']           = 'SMTP серверийн алдаа: ';
+$PHPMAILER_LANG['variable_set']         = 'Хувьсагчийг тохируулах эсвэл дахин тохируулах боломжгүй байна: ';
+$PHPMAILER_LANG['extension_missing']    = 'Өргөтгөл байхгүй: ';

--- a/language/phpmailer.lang-ms.php
+++ b/language/phpmailer.lang-ms.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Malaysian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Nawawi Jamili <nawawi@rutweb.com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'Ralat SMTP: Tidak dapat pengesahan.';
+$PHPMAILER_LANG['connect_host']         = 'Ralat SMTP: Tidak dapat menghubungi hos pelayan SMTP.';
+$PHPMAILER_LANG['data_not_accepted']    = 'Ralat SMTP: Data tidak diterima oleh pelayan.';
+$PHPMAILER_LANG['empty_message']        = 'Tiada isi untuk mesej';
+$PHPMAILER_LANG['encoding']             = 'Pengekodan tidak diketahui: ';
+$PHPMAILER_LANG['execute']              = 'Tidak dapat melaksanakan: ';
+$PHPMAILER_LANG['file_access']          = 'Tidak dapat mengakses fail: ';
+$PHPMAILER_LANG['file_open']            = 'Ralat Fail: Tidak dapat membuka fail: ';
+$PHPMAILER_LANG['from_failed']          = 'Berikut merupakan ralat dari alamat e-mel: ';
+$PHPMAILER_LANG['instantiate']          = 'Tidak dapat memberi contoh fungsi e-mel.';
+$PHPMAILER_LANG['invalid_address']      = 'Alamat emel tidak sah: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' jenis penghantar emel tidak disokong.';
+$PHPMAILER_LANG['provide_address']      = 'Anda perlu menyediakan sekurang-kurangnya satu alamat e-mel penerima.';
+$PHPMAILER_LANG['recipients_failed']    = 'Ralat SMTP: Penerima e-mel berikut telah gagal: ';
+$PHPMAILER_LANG['signing']              = 'Ralat pada tanda tangan: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() telah gagal.';
+$PHPMAILER_LANG['smtp_error']           = 'Ralat pada pelayan SMTP: ';
+$PHPMAILER_LANG['variable_set']         = 'Tidak boleh menetapkan atau menetapkan semula pembolehubah: ';
+$PHPMAILER_LANG['extension_missing']    = 'Sambungan hilang: ';

--- a/language/phpmailer.lang-nb.php
+++ b/language/phpmailer.lang-nb.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Norwegian Bokmål PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Wera AS <wordpress@wera.no>
+ */
+
+ $PHPMAILER_LANG['authenticate']         = 'SMTP-feil: Kunne ikke autentisere.';
+ $PHPMAILER_LANG['buggy_php']            = 'Din versjon av PHP er påvirket av en feil som kan føre til ødelagte meldinger. For å løse problemet kan du bytte til sending via SMTP, deaktivere mail.add_x_header-alternativet i php.ini, bytte til MacOS eller Linux, eller oppgradere PHP til versjon 7.0.17+ eller 7.1.3+.';
+ $PHPMAILER_LANG['connect_host']         = 'SMTP-feil: Kunne ikke koble til SMTP-vert.';
+ $PHPMAILER_LANG['data_not_accepted']    = 'SMTP-feil: data ikke akseptert.';
+ $PHPMAILER_LANG['empty_message']        = 'Meldingsinnholdet er tomt';
+ $PHPMAILER_LANG['encoding']             = 'Ukjent koding: ';
+ $PHPMAILER_LANG['execute']              = 'Kunne ikke utføres: ';
+ $PHPMAILER_LANG['extension_missing']    = 'Utvidelse mangler: ';
+ $PHPMAILER_LANG['file_access']          = 'Kunne ikke få tilgang til filen: ';
+ $PHPMAILER_LANG['file_open']            = 'Feil i fil: Kunne ikke åpne filen: ';
+ $PHPMAILER_LANG['from_failed']          = 'Følgende avsenderadresse mislyktes: ';
+ $PHPMAILER_LANG['instantiate']          = 'Kunne ikke starte e-postfunksjonen.';
+ $PHPMAILER_LANG['invalid_address']      = 'Ugyldig adresse: ';
+ $PHPMAILER_LANG['invalid_header']       = 'Ugyldig headernavn eller verdi';
+ $PHPMAILER_LANG['invalid_hostentry']    = 'Ugyldig vertsinngang: ';
+ $PHPMAILER_LANG['invalid_host']         = 'Ugyldig vert: ';
+ $PHPMAILER_LANG['mailer_not_supported'] = ' sender er ikke støttet.';
+ $PHPMAILER_LANG['provide_address']      = 'Du må oppgi minst én mottaker-e-postadresse.';
+ $PHPMAILER_LANG['recipients_failed']    = 'SMTP Feil: Følgende mottakeradresse feilet: ';
+ $PHPMAILER_LANG['signing']              = 'Signeringsfeil: ';
+ $PHPMAILER_LANG['smtp_code']            = 'SMTP-kode: ';
+ $PHPMAILER_LANG['smtp_code_ex']         = 'Ytterligere SMTP-info: ';
+ $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP connect() mislyktes.';
+ $PHPMAILER_LANG['smtp_detail']          = 'Detaljer: ';
+ $PHPMAILER_LANG['smtp_error']           = 'SMTP-serverfeil: ';
+ $PHPMAILER_LANG['variable_set']         = 'Kan ikke angi eller tilbakestille variabel: ';
+ $PHPMAILER_LANG['no_smtputf8']          = 'Serveren støtter ikke SMTPUTF8, som er nødvendig for å sende til Unicode-adresser.';
+ $PHPMAILER_LANG['imap_recommended']     = 'Det anbefales ikke å bruke forenklet adresseanalyse. Installer PHP IMAP-utvidelsen for full RFC822-analyse.';
+ $PHPMAILER_LANG['deprecated_argument']  = 'Avviklet argument: ';

--- a/language/phpmailer.lang-nl.php
+++ b/language/phpmailer.lang-nl.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Dutch PHPMailer language file: refer to PHPMailer.php for definitive list.
+ * @package PHPMailer
+ * @author Tuxion <team@tuxion.nl>
+ * @author Robin van der Vliet <info@robinvandervliet.com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP-fout: authenticatie mislukt.';
+$PHPMAILER_LANG['buggy_php']            = 'PHP-versie gedetecteerd die onderhevig is aan een bug die kan resulteren in gecorrumpeerde berichten. Om dit te voorkomen, gebruik SMTP voor het verzenden van berichten, zet de optie mail.add_x_header in uw php.ini uit, gebruik MacOS of Linux, of pas de gebruikte PHP-versie aan naar versie 7.0.17+ or 7.1.3+.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP-fout: kon niet verbinden met SMTP-host.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP-fout: data niet geaccepteerd.';
+$PHPMAILER_LANG['empty_message']        = 'Berichttekst is leeg';
+$PHPMAILER_LANG['encoding']             = 'Onbekende codering: ';
+$PHPMAILER_LANG['execute']              = 'Kon niet uitvoeren: ';
+$PHPMAILER_LANG['extension_missing']    = 'Extensie afwezig: ';
+$PHPMAILER_LANG['file_access']          = 'Kreeg geen toegang tot bestand: ';
+$PHPMAILER_LANG['file_open']            = 'Bestandsfout: kon bestand niet openen: ';
+$PHPMAILER_LANG['from_failed']          = 'Het volgende afzenderadres is mislukt: ';
+$PHPMAILER_LANG['instantiate']          = 'Kon mailfunctie niet initialiseren.';
+$PHPMAILER_LANG['invalid_address']      = 'Ongeldig adres: ';
+$PHPMAILER_LANG['invalid_header']       = 'Ongeldige headernaam of -waarde';
+$PHPMAILER_LANG['invalid_hostentry']    = 'Ongeldige hostentry: ';
+$PHPMAILER_LANG['invalid_host']         = 'Ongeldige host: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' mailer wordt niet ondersteund.';
+$PHPMAILER_LANG['provide_address']      = 'Er moet minstens één ontvanger worden opgegeven.';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP-fout: de volgende ontvangers zijn mislukt: ';
+$PHPMAILER_LANG['signing']              = 'Signeerfout: ';
+$PHPMAILER_LANG['smtp_code']            = 'SMTP-code: ';
+$PHPMAILER_LANG['smtp_code_ex']         = 'Aanvullende SMTP-informatie: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP-verbinding mislukt.';
+$PHPMAILER_LANG['smtp_detail']          = 'Detail: ';
+$PHPMAILER_LANG['smtp_error']           = 'SMTP-serverfout: ';
+$PHPMAILER_LANG['variable_set']         = 'Kan de volgende variabele niet instellen of herstellen: ';
+$PHPMAILER_LANG['no_smtputf8']          = 'De server ondersteunt geen SMTPUTF8 dat nodig is om naar Unicode-adressen te sturen.';
+$PHPMAILER_LANG['imap_recommended']     = 'Het gebruik van de vereenvoudigde adresparser is niet aanbevolen. Installeer de IMAP-extensie voor PHP voor volledige RFC822-ondersteuning.';
+$PHPMAILER_LANG['deprecated_argument']  = 'Verouderd argument: ';

--- a/language/phpmailer.lang-pl.php
+++ b/language/phpmailer.lang-pl.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Polish PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'Błąd SMTP: nie udało się przeprowadzić uwierzytelnienia.';
+$PHPMAILER_LANG['buggy_php']            = 'Używana wersja PHP zawiera błąd, który może powodować uszkodzenie wiadomości. Aby temu zapobiec, użyj wysyłki przez SMTP, wyłącz opcję mail.add_x_header w php.ini, przejdź na macOS lub Linux, lub zaktualizuj PHP do wersji 7.0.17+ albo 7.1.3+.';
+$PHPMAILER_LANG['connect_host']         = 'Błąd SMTP: nie udało się połączyć z serwerem (hostem).';
+$PHPMAILER_LANG['data_not_accepted']    = 'Błąd SMTP: dane wiadomości nie zostały przyjęte przez serwer.';
+$PHPMAILER_LANG['empty_message']        = 'Nie można wysłać pustej wiadomości.';
+$PHPMAILER_LANG['encoding']             = 'Nieobsługiwane kodowanie znaków: ';
+$PHPMAILER_LANG['execute']              = 'Nie udało się uruchomić polecenia: ';
+$PHPMAILER_LANG['extension_missing']    = 'Brak wymaganego rozszerzenia PHP: ';
+$PHPMAILER_LANG['file_access']          = 'Brak dostępu do pliku: ';
+$PHPMAILER_LANG['file_open']            = 'Nie udało się otworzyć pliku: ';
+$PHPMAILER_LANG['from_failed']          = 'Nieprawidłowy adres nadawcy: ';
+$PHPMAILER_LANG['instantiate']          = 'Nie można zainicjować funkcji mail(). Sprawdź konfigurację serwera.';
+$PHPMAILER_LANG['invalid_address']      = 'Nie można wysłać wiadomości. Nieprawidłowy adres odbiorcy: ';
+$PHPMAILER_LANG['invalid_header']       = 'Nieprawidłowa nazwa lub wartość nagłówka.';
+$PHPMAILER_LANG['invalid_hostentry']    = 'Nieprawidłowy wpis hosta: ';
+$PHPMAILER_LANG['invalid_host']         = 'Nieprawidłowa nazwa hosta: ';
+$PHPMAILER_LANG['provide_address']      = 'Musisz podać co najmniej jeden prawidłowy adres e-mail odbiorcy.';
+$PHPMAILER_LANG['mailer_not_supported'] = 'Wybrana metoda wysyłki wiadomości nie jest obsługiwana.';
+$PHPMAILER_LANG['recipients_failed']    = 'Błąd SMTP: nie udało się wysłać do następujących odbiorców: ';
+$PHPMAILER_LANG['signing']              = 'Błąd podpisywania wiadomości cyfrowo: ';
+$PHPMAILER_LANG['smtp_code']            = 'Kod odpowiedzi SMTP: ';
+$PHPMAILER_LANG['smtp_code_ex']         = 'Dodatkowe informacje serwera SMTP: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'Nie udało się nawiązać połączenia za pomocą SMTP Connect().';
+$PHPMAILER_LANG['smtp_detail']          = 'Szczegóły błędu: ';
+$PHPMAILER_LANG['smtp_error']           = 'Błąd serwera SMTP: ';
+$PHPMAILER_LANG['variable_set']         = 'Nie można ustawić lub zmodyfikować zmiennej: ';

--- a/language/phpmailer.lang-pt.php
+++ b/language/phpmailer.lang-pt.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Portuguese (European) PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author João Vieira <mail@joaovieira.eu>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'Erro SMTP: Falha na autenticação.';
+$PHPMAILER_LANG['buggy_php']            = 'A sua versão do PHP tem um bug que pode causar mensagens corrompidas. Para resolver, utilize o envio por SMTP, desative a opção mail.add_x_header no ficheiro php.ini, mude para MacOS ou Linux, ou atualize o PHP para a versão 7.0.17+ ou 7.1.3+.';
+$PHPMAILER_LANG['connect_host']         = 'Erro SMTP: Não foi possível ligar ao servidor SMTP.';
+$PHPMAILER_LANG['data_not_accepted']    = 'Erro SMTP: Dados não aceites.';
+$PHPMAILER_LANG['empty_message']        = 'A mensagem de e-mail está vazia.';
+$PHPMAILER_LANG['encoding']             = 'Codificação desconhecida: ';
+$PHPMAILER_LANG['execute']              = 'Não foi possível executar: ';
+$PHPMAILER_LANG['extension_missing']    = 'Extensão em falta: ';
+$PHPMAILER_LANG['file_access']          = 'Não foi possível aceder ao ficheiro: ';
+$PHPMAILER_LANG['file_open']            = 'Erro ao abrir o ficheiro: ';
+$PHPMAILER_LANG['from_failed']          = 'O envio falhou para o seguinte endereço do remetente: ';
+$PHPMAILER_LANG['instantiate']          = 'Não foi possível instanciar a função mail.';
+$PHPMAILER_LANG['invalid_address']      = 'Endereço de e-mail inválido: ';
+$PHPMAILER_LANG['invalid_header']       = 'Nome ou valor do cabeçalho inválido.';
+$PHPMAILER_LANG['invalid_hostentry']    = 'Entrada de host inválida: ';
+$PHPMAILER_LANG['invalid_host']         = 'Host inválido: ';
+$PHPMAILER_LANG['mailer_not_supported'] = 'O cliente de e-mail não é suportado.';
+$PHPMAILER_LANG['provide_address']      = 'Deve fornecer pelo menos um endereço de destinatário.';
+$PHPMAILER_LANG['recipients_failed']    = 'Erro SMTP: Falha no envio para os seguintes destinatários: ';
+$PHPMAILER_LANG['signing']              = 'Erro ao assinar: ';
+$PHPMAILER_LANG['smtp_code']            = 'Código SMTP: ';
+$PHPMAILER_LANG['smtp_code_ex']         = 'Informações adicionais SMTP: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'Falha na função SMTP connect().';
+$PHPMAILER_LANG['smtp_detail']          = 'Detalhes: ';
+$PHPMAILER_LANG['smtp_error']           = 'Erro do servidor SMTP: ';
+$PHPMAILER_LANG['variable_set']         = 'Não foi possível definir ou redefinir a variável: ';

--- a/language/phpmailer.lang-pt_br.php
+++ b/language/phpmailer.lang-pt_br.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Brazilian Portuguese PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Paulo Henrique Garcia <paulo@controllerweb.com.br>
+ * @author Lucas Guimarães <lucas@lucasguimaraes.com>
+ * @author Phelipe Alves <phelipealvesdesouza@gmail.com>
+ * @author Fabio Beneditto <fabiobeneditto@gmail.com>
+ * @author Geidson Benício Coelho <geidsonc@gmail.com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'Erro de SMTP: Não foi possível autenticar.';
+$PHPMAILER_LANG['buggy_php']            = 'Sua versão do PHP é afetada por um bug que por resultar em messagens corrompidas. Para corrigir, mude para enviar usando SMTP, desative a opção mail.add_x_header em seu php.ini, mude para MacOS ou Linux, ou atualize seu PHP para versão 7.0.17+ ou 7.1.3+ ';
+$PHPMAILER_LANG['connect_host']         = 'Erro de SMTP: Não foi possível conectar ao servidor SMTP.';
+$PHPMAILER_LANG['data_not_accepted']    = 'Erro de SMTP: Dados rejeitados.';
+$PHPMAILER_LANG['empty_message']        = 'Mensagem vazia';
+$PHPMAILER_LANG['encoding']             = 'Codificação desconhecida: ';
+$PHPMAILER_LANG['execute']              = 'Não foi possível executar: ';
+$PHPMAILER_LANG['extension_missing']    = 'Extensão não existe: ';
+$PHPMAILER_LANG['file_access']          = 'Não foi possível acessar o arquivo: ';
+$PHPMAILER_LANG['file_open']            = 'Erro de Arquivo: Não foi possível abrir o arquivo: ';
+$PHPMAILER_LANG['from_failed']          = 'Os seguintes remetentes falharam: ';
+$PHPMAILER_LANG['instantiate']          = 'Não foi possível instanciar a função mail.';
+$PHPMAILER_LANG['invalid_address']      = 'Endereço de e-mail inválido: ';
+$PHPMAILER_LANG['invalid_header']       = 'Nome ou valor de cabeçalho inválido';
+$PHPMAILER_LANG['invalid_hostentry']    = 'hostentry inválido: ';
+$PHPMAILER_LANG['invalid_host']         = 'host inválido: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' mailer não é suportado.';
+$PHPMAILER_LANG['provide_address']      = 'Você deve informar pelo menos um destinatário.';
+$PHPMAILER_LANG['recipients_failed']    = 'Erro de SMTP: Os seguintes destinatários falharam: ';
+$PHPMAILER_LANG['signing']              = 'Erro de Assinatura: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() falhou.';
+$PHPMAILER_LANG['smtp_code']            = 'Código do servidor SMTP: ';
+$PHPMAILER_LANG['smtp_error']           = 'Erro de servidor SMTP: ';
+$PHPMAILER_LANG['smtp_code_ex']         = 'Informações adicionais do servidor SMTP: ';
+$PHPMAILER_LANG['smtp_detail']          = 'Detalhes do servidor SMTP: ';
+$PHPMAILER_LANG['variable_set']         = 'Não foi possível definir ou redefinir a variável: ';

--- a/language/phpmailer.lang-ro.php
+++ b/language/phpmailer.lang-ro.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Romanian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'Eroare SMTP: Autentificarea a eșuat.';
+$PHPMAILER_LANG['buggy_php']            = 'Versiunea instalată de PHP este afectată de o problemă care poate duce la coruperea mesajelor Pentru a preveni această problemă, folosiți SMTP, dezactivați opțiunea mail.add_x_header din php.ini, folosiți MacOS/Linux sau actualizați versiunea de PHP la 7.0.17+ sau 7.1.3+.';
+$PHPMAILER_LANG['connect_host']         = 'Eroare SMTP: Conectarea la serverul SMTP a eșuat.';
+$PHPMAILER_LANG['data_not_accepted']    = 'Eroare SMTP: Datele nu au fost acceptate.';
+$PHPMAILER_LANG['empty_message']        = 'Mesajul este gol.';
+$PHPMAILER_LANG['encoding']             = 'Encodare necunoscută: ';
+$PHPMAILER_LANG['execute']              = 'Nu se poate executa următoarea comandă:  ';
+$PHPMAILER_LANG['extension_missing']    = 'Lipsește extensia: ';
+$PHPMAILER_LANG['file_access']          = 'Nu se poate accesa următorul fișier: ';
+$PHPMAILER_LANG['file_open']            = 'Eroare fișier: Nu se poate deschide următorul fișier: ';
+$PHPMAILER_LANG['from_failed']          = 'Următoarele adrese From au dat eroare: ';
+$PHPMAILER_LANG['instantiate']          = 'Funcția mail nu a putut fi inițializată.';
+$PHPMAILER_LANG['invalid_address']      = 'Adresa de email nu este validă: ';
+$PHPMAILER_LANG['invalid_header']       = 'Numele sau valoarea header-ului nu este validă: ';
+$PHPMAILER_LANG['invalid_hostentry']    = 'Hostentry invalid: ';
+$PHPMAILER_LANG['invalid_host']         = 'Host invalid: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' mailer nu este suportat.';
+$PHPMAILER_LANG['provide_address']      = 'Trebuie să adăugați cel puțin o adresă de email.';
+$PHPMAILER_LANG['recipients_failed']    = 'Eroare SMTP: Următoarele adrese de email au eșuat: ';
+$PHPMAILER_LANG['signing']              = 'A aparut o problemă la semnarea emailului. ';
+$PHPMAILER_LANG['smtp_code']            = 'Cod SMTP: ';
+$PHPMAILER_LANG['smtp_code_ex']         = 'Informații SMTP adiționale: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'Conectarea la serverul SMTP a eșuat.';
+$PHPMAILER_LANG['smtp_detail']          = 'Detalii SMTP: ';
+$PHPMAILER_LANG['smtp_error']           = 'Eroare server SMTP: ';
+$PHPMAILER_LANG['variable_set']         = 'Nu se poate seta/reseta variabila. ';

--- a/language/phpmailer.lang-ru.php
+++ b/language/phpmailer.lang-ru.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Russian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Alexey Chumakov <alex@chumakov.ru>
+ * @author Foster Snowhill <i18n@forstwoof.ru>
+ * @author ProjectSoft <projectsoft2009@yandex.ru>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'Ошибка SMTP: не удалось пройти аутентификацию.';
+$PHPMAILER_LANG['buggy_php']            = 'В вашей версии PHP есть ошибка, которая может привести к повреждению сообщений. Чтобы исправить, переключитесь на отправку по SMTP, отключите опцию mail.add_x_header в ваш php.ini, переключитесь на MacOS или Linux или обновите PHP до версии 7.0.17+ или 7.1.3+.';
+$PHPMAILER_LANG['connect_host']         = 'Ошибка SMTP: не удается подключиться к SMTP-серверу.';
+$PHPMAILER_LANG['data_not_accepted']    = 'Ошибка SMTP: данные не приняты.';
+$PHPMAILER_LANG['empty_message']        = 'Пустое сообщение';
+$PHPMAILER_LANG['encoding']             = 'Неизвестная кодировка: ';
+$PHPMAILER_LANG['execute']              = 'Невозможно выполнить команду: ';
+$PHPMAILER_LANG['extension_missing']    = 'Расширение отсутствует: ';
+$PHPMAILER_LANG['file_access']          = 'Нет доступа к файлу: ';
+$PHPMAILER_LANG['file_open']            = 'Файловая ошибка: не удаётся открыть файл: ';
+$PHPMAILER_LANG['from_failed']          = 'Неверный адрес отправителя: ';
+$PHPMAILER_LANG['instantiate']          = 'Невозможно запустить функцию mail().';
+$PHPMAILER_LANG['invalid_address']      = 'Не отправлено из-за неправильного формата email-адреса: ';
+$PHPMAILER_LANG['invalid_header']       = 'Неверное имя или значение заголовка';
+$PHPMAILER_LANG['invalid_hostentry']    = 'Неверная запись хоста: ';
+$PHPMAILER_LANG['invalid_host']         = 'Неверный хост: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' — почтовый сервер не поддерживается.';
+$PHPMAILER_LANG['provide_address']      = 'Вы должны указать хотя бы один адрес электронной почты получателя.';
+$PHPMAILER_LANG['recipients_failed']    = 'Ошибка SMTP: Ошибка следующих получателей: ';
+$PHPMAILER_LANG['signing']              = 'Ошибка подписи: ';
+$PHPMAILER_LANG['smtp_code']            = 'Код SMTP: ';
+$PHPMAILER_LANG['smtp_code_ex']         = 'Дополнительная информация SMTP: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'Ошибка соединения с SMTP-сервером.';
+$PHPMAILER_LANG['smtp_detail']          = 'Детали: ';
+$PHPMAILER_LANG['smtp_error']           = 'Ошибка SMTP-сервера: ';
+$PHPMAILER_LANG['variable_set']         = 'Невозможно установить или сбросить переменную: ';

--- a/language/phpmailer.lang-si.php
+++ b/language/phpmailer.lang-si.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Sinhalese PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Ayesh Karunaratne <ayesh@aye.sh>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP දෝෂය: සත්‍යාපනය අසාර්ථක විය.';
+$PHPMAILER_LANG['buggy_php']            = 'ඔබගේ PHP version එකෙහි පවතින දෝෂයක් නිසා email පණිවිඩ දෝෂ සහගත වීමේ හැකියාවක් ඇත. මෙය විසදීම සදහා SMTP භාවිතා කිරීම, mail.add_x_header INI setting එක අක්‍රීය කිරීම, MacOS හෝ Linux වලට මාරු වීම, හෝ ඔබගේ PHP version එක 7.0.17+ හෝ 7.1.3+ වලට අලුත් කිරීම කරගන්න.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP දෝෂය: සම්බන්ධ වීමට නොහැකි විය.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP දෝෂය: දත්ත පිළිගනු නොලැබේ.';
+$PHPMAILER_LANG['empty_message']        = 'පණිවිඩ අන්තර්ගතය හිස්';
+$PHPMAILER_LANG['encoding']             = 'නොදන්නා කේතනය: ';
+$PHPMAILER_LANG['execute']              = 'ක්‍රියාත්මක කළ නොහැකි විය: ';
+$PHPMAILER_LANG['extension_missing']    = 'Extension එක නොමැත: ';
+$PHPMAILER_LANG['file_access']          = 'File එකට ප්‍රවේශ විය නොහැකි විය: ';
+$PHPMAILER_LANG['file_open']            = 'File දෝෂය: File එක විවෘත කළ නොහැක: ';
+$PHPMAILER_LANG['from_failed']          = 'පහත From ලිපිනයන් අසාර්ථක විය: ';
+$PHPMAILER_LANG['instantiate']          = 'mail function එක ක්‍රියාත්මක කළ නොහැක.';
+$PHPMAILER_LANG['invalid_address']      = 'වලංගු නොවන ලිපිනය: ';
+$PHPMAILER_LANG['invalid_header']       = 'වලංගු නොවන header නාමයක් හෝ අගයක්';
+$PHPMAILER_LANG['invalid_hostentry']    = 'වලංගු නොවන hostentry එකක්: ';
+$PHPMAILER_LANG['invalid_host']         = 'වලංගු නොවන host එකක්: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' mailer සහාය නොදක්වයි.';
+$PHPMAILER_LANG['provide_address']      = 'ඔබ අවම වශයෙන් එක් ලබන්නෙකුගේ ඊමේල් ලිපිනයක් සැපයිය යුතුය.';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP දෝෂය: පහත ලබන්නන් අසමත් විය: ';
+$PHPMAILER_LANG['signing']              = 'Sign කිරීමේ දෝෂය: ';
+$PHPMAILER_LANG['smtp_code']            = 'SMTP කේතය: ';
+$PHPMAILER_LANG['smtp_code_ex']         = 'අමතර SMTP තොරතුරු: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP සම්බන්ධය අසාර්ථක විය.';
+$PHPMAILER_LANG['smtp_detail']          = 'තොරතුරු: ';
+$PHPMAILER_LANG['smtp_error']           = 'SMTP දෝෂය: ';
+$PHPMAILER_LANG['variable_set']         = 'Variable එක සැකසීමට හෝ නැවත සැකසීමට නොහැක: ';

--- a/language/phpmailer.lang-sk.php
+++ b/language/phpmailer.lang-sk.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Slovak PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Michal Tinka <michaltinka@gmail.com>
+ * @author Peter Orlický <pcmanik91@gmail.com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP Error: Chyba autentifikácie.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP Error: Nebolo možné nadviazať spojenie so SMTP serverom.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP Error: Dáta neboli prijaté';
+$PHPMAILER_LANG['empty_message']        = 'Prázdne telo správy.';
+$PHPMAILER_LANG['encoding']             = 'Neznáme kódovanie: ';
+$PHPMAILER_LANG['execute']              = 'Nedá sa vykonať: ';
+$PHPMAILER_LANG['file_access']          = 'Súbor nebol nájdený: ';
+$PHPMAILER_LANG['file_open']            = 'File Error: Súbor sa otvoriť pre čítanie: ';
+$PHPMAILER_LANG['from_failed']          = 'Následujúca adresa From je nesprávna: ';
+$PHPMAILER_LANG['instantiate']          = 'Nedá sa vytvoriť inštancia emailovej funkcie.';
+$PHPMAILER_LANG['invalid_address']      = 'Neodoslané, emailová adresa je nesprávna: ';
+$PHPMAILER_LANG['invalid_hostentry']    = 'Záznam hostiteľa je nesprávny: ';
+$PHPMAILER_LANG['invalid_host']         = 'Hostiteľ je nesprávny: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' emailový klient nieje podporovaný.';
+$PHPMAILER_LANG['provide_address']      = 'Musíte zadať aspoň jednu emailovú adresu príjemcu.';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP Error: Adresy príjemcov niesu správne ';
+$PHPMAILER_LANG['signing']              = 'Chyba prihlasovania: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() zlyhalo.';
+$PHPMAILER_LANG['smtp_error']           = 'SMTP chyba serveru: ';
+$PHPMAILER_LANG['variable_set']         = 'Nemožno nastaviť alebo resetovať premennú: ';
+$PHPMAILER_LANG['extension_missing']    = 'Chýba rozšírenie: ';

--- a/language/phpmailer.lang-sl.php
+++ b/language/phpmailer.lang-sl.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Slovene PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Klemen Tušar <techouse@gmail.com>
+ * @author Filip Š <projects@filips.si>
+ * @author Blaž Oražem <blaz@orazem.si>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP napaka: Avtentikacija ni uspela.';
+$PHPMAILER_LANG['buggy_php']            = 'Na vašo PHP različico vpliva napaka, ki lahko povzroči poškodovana sporočila. Če želite težavo odpraviti, preklopite na pošiljanje prek SMTP, onemogočite možnost mail.add_x_header v vaši php.ini datoteki, preklopite na MacOS ali Linux, ali nadgradite vašo PHP zaličico na 7.0.17+ ali 7.1.3+.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP napaka: Vzpostavljanje povezave s SMTP gostiteljem ni uspelo.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP napaka: Strežnik zavrača podatke.';
+$PHPMAILER_LANG['empty_message']        = 'E-poštno sporočilo nima vsebine.';
+$PHPMAILER_LANG['encoding']             = 'Nepoznan tip kodiranja: ';
+$PHPMAILER_LANG['execute']              = 'Operacija ni uspela: ';
+$PHPMAILER_LANG['extension_missing']    = 'Manjkajoča razširitev: ';
+$PHPMAILER_LANG['file_access']          = 'Nimam dostopa do datoteke: ';
+$PHPMAILER_LANG['file_open']            = 'Ne morem odpreti datoteke: ';
+$PHPMAILER_LANG['from_failed']          = 'Neveljaven e-naslov pošiljatelja: ';
+$PHPMAILER_LANG['instantiate']          = 'Ne morem inicializirati mail funkcije.';
+$PHPMAILER_LANG['invalid_address']      = 'E-poštno sporočilo ni bilo poslano. E-naslov je neveljaven: ';
+$PHPMAILER_LANG['invalid_header']       = 'Neveljavno ime ali vrednost glave';
+$PHPMAILER_LANG['invalid_hostentry']    = 'Neveljaven vnos gostitelja: ';
+$PHPMAILER_LANG['invalid_host']         = 'Neveljaven gostitelj: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' mailer ni podprt.';
+$PHPMAILER_LANG['provide_address']      = 'Prosimo, vnesite vsaj enega naslovnika.';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP napaka: Sledeči naslovniki so neveljavni: ';
+$PHPMAILER_LANG['signing']              = 'Napaka pri podpisovanju: ';
+$PHPMAILER_LANG['smtp_code']            = 'SMTP koda: ';
+$PHPMAILER_LANG['smtp_code_ex']         = 'Dodatne informacije o SMTP: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'Ne morem vzpostaviti povezave s SMTP strežnikom.';
+$PHPMAILER_LANG['smtp_detail']          = 'Podrobnosti: ';
+$PHPMAILER_LANG['smtp_error']           = 'Napaka SMTP strežnika: ';
+$PHPMAILER_LANG['variable_set']         = 'Ne morem nastaviti oz. ponastaviti spremenljivke: ';

--- a/language/phpmailer.lang-sr.php
+++ b/language/phpmailer.lang-sr.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Serbian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Александар Јевремовић <ajevremovic@gmail.com>
+ * @author Miloš Milanović <mmilanovic016@gmail.com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP грешка: аутентификација није успела.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP грешка: повезивање са SMTP сервером није успело.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP грешка: подаци нису прихваћени.';
+$PHPMAILER_LANG['empty_message']        = 'Садржај поруке је празан.';
+$PHPMAILER_LANG['encoding']             = 'Непознато кодирање: ';
+$PHPMAILER_LANG['execute']              = 'Није могуће извршити наредбу: ';
+$PHPMAILER_LANG['file_access']          = 'Није могуће приступити датотеци: ';
+$PHPMAILER_LANG['file_open']            = 'Није могуће отворити датотеку: ';
+$PHPMAILER_LANG['from_failed']          = 'SMTP грешка: слање са следећих адреса није успело: ';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP грешка: слање на следеће адресе није успело: ';
+$PHPMAILER_LANG['instantiate']          = 'Није могуће покренути mail функцију.';
+$PHPMAILER_LANG['invalid_address']      = 'Порука није послата. Неисправна адреса: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' мејлер није подржан.';
+$PHPMAILER_LANG['provide_address']      = 'Дефинишите бар једну адресу примаоца.';
+$PHPMAILER_LANG['signing']              = 'Грешка приликом пријаве: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'Повезивање са SMTP сервером није успело.';
+$PHPMAILER_LANG['smtp_error']           = 'Грешка SMTP сервера: ';
+$PHPMAILER_LANG['variable_set']         = 'Није могуће задати нити ресетовати променљиву: ';
+$PHPMAILER_LANG['extension_missing']    = 'Недостаје проширење: ';

--- a/language/phpmailer.lang-sr_latn.php
+++ b/language/phpmailer.lang-sr_latn.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Serbian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Александар Јевремовић <ajevremovic@gmail.com>
+ * @author Miloš Milanović <mmilanovic016@gmail.com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP greška: autentifikacija nije uspela.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP greška: povezivanje sa SMTP serverom nije uspelo.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP greška: podaci nisu prihvaćeni.';
+$PHPMAILER_LANG['empty_message']        = 'Sadržaj poruke je prazan.';
+$PHPMAILER_LANG['encoding']             = 'Nepoznato kodiranje: ';
+$PHPMAILER_LANG['execute']              = 'Nije moguće izvršiti naredbu: ';
+$PHPMAILER_LANG['file_access']          = 'Nije moguće pristupiti datoteci: ';
+$PHPMAILER_LANG['file_open']            = 'Nije moguće otvoriti datoteku: ';
+$PHPMAILER_LANG['from_failed']          = 'SMTP greška: slanje sa sledećih adresa nije uspelo: ';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP greška: slanje na sledeće adrese nije uspelo: ';
+$PHPMAILER_LANG['instantiate']          = 'Nije moguće pokrenuti mail funkciju.';
+$PHPMAILER_LANG['invalid_address']      = 'Poruka nije poslata. Neispravna adresa: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' majler nije podržan.';
+$PHPMAILER_LANG['provide_address']      = 'Definišite bar jednu adresu primaoca.';
+$PHPMAILER_LANG['signing']              = 'Greška prilikom prijave: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'Povezivanje sa SMTP serverom nije uspelo.';
+$PHPMAILER_LANG['smtp_error']           = 'Greška SMTP servera: ';
+$PHPMAILER_LANG['variable_set']         = 'Nije moguće zadati niti resetovati promenljivu: ';
+$PHPMAILER_LANG['extension_missing']    = 'Nedostaje proširenje: ';

--- a/language/phpmailer.lang-sv.php
+++ b/language/phpmailer.lang-sv.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Swedish PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Johan Linnér <johan@linner.biz>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP fel: Kunde inte autentisera.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP fel: Kunde inte ansluta till SMTP-server.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP fel: Data accepterades inte.';
+//$PHPMAILER_LANG['empty_message']        = 'Message body empty';
+$PHPMAILER_LANG['encoding']             = 'Okänt encode-format: ';
+$PHPMAILER_LANG['execute']              = 'Kunde inte köra: ';
+$PHPMAILER_LANG['file_access']          = 'Ingen åtkomst till fil: ';
+$PHPMAILER_LANG['file_open']            = 'Fil fel: Kunde inte öppna fil: ';
+$PHPMAILER_LANG['from_failed']          = 'Följande avsändaradress är felaktig: ';
+$PHPMAILER_LANG['instantiate']          = 'Kunde inte initiera e-postfunktion.';
+$PHPMAILER_LANG['invalid_address']      = 'Felaktig adress: ';
+$PHPMAILER_LANG['provide_address']      = 'Du måste ange minst en mottagares e-postadress.';
+$PHPMAILER_LANG['mailer_not_supported'] = ' mailer stöds inte.';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP fel: Följande mottagare är felaktig: ';
+$PHPMAILER_LANG['signing']              = 'Signeringsfel: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() misslyckades.';
+$PHPMAILER_LANG['smtp_error']           = 'SMTP serverfel: ';
+$PHPMAILER_LANG['variable_set']         = 'Kunde inte definiera eller återställa variabel: ';
+$PHPMAILER_LANG['extension_missing']    = 'Tillägg ej tillgängligt: ';

--- a/language/phpmailer.lang-tl.php
+++ b/language/phpmailer.lang-tl.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Tagalog PHPMailer language file: refer to English translation for definitive list
+ *
+ *   @package PHPMailer
+ *   @author Adriane Justine Tan <eidoriantan@gmail.com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP Error: Hindi mapatotohanan.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP Error: Hindi makakonekta sa SMTP host.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP Error: Ang datos ay hindi naitanggap.';
+$PHPMAILER_LANG['empty_message']        = 'Walang laman ang mensahe';
+$PHPMAILER_LANG['encoding']             = 'Hindi alam ang encoding: ';
+$PHPMAILER_LANG['execute']              = 'Hindi maisasagawa: ';
+$PHPMAILER_LANG['file_access']          = 'Hindi ma-access ang file: ';
+$PHPMAILER_LANG['file_open']            = 'File Error: Hindi mabuksan ang file: ';
+$PHPMAILER_LANG['from_failed']          = 'Ang sumusunod na address ay nabigo: ';
+$PHPMAILER_LANG['instantiate']          = 'Hindi maisimulan ang instance ng mail function.';
+$PHPMAILER_LANG['invalid_address']      = 'Hindi wasto ang address na naibigay: ';
+$PHPMAILER_LANG['mailer_not_supported'] = 'Ang mailer ay hindi suportado.';
+$PHPMAILER_LANG['provide_address']      = 'Kailangan mong magbigay ng kahit isang email address na tatanggap.';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP Error: Ang mga sumusunod na tatanggap ay nabigo: ';
+$PHPMAILER_LANG['signing']              = 'Hindi ma-sign: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'Ang SMTP connect() ay nabigo.';
+$PHPMAILER_LANG['smtp_error']           = 'Ang server ng SMTP ay nabigo: ';
+$PHPMAILER_LANG['variable_set']         = 'Hindi matatakda o ma-reset ang mga variables: ';
+$PHPMAILER_LANG['extension_missing']    = 'Nawawala ang extension: ';

--- a/language/phpmailer.lang-tr.php
+++ b/language/phpmailer.lang-tr.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Turkish PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Elçin Özel
+ * @author Can Yılmaz
+ * @author Mehmet Benlioğlu
+ * @author @yasinaydin
+ * @author Ogün Karakuş
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP Hatası: Oturum açılamadı.';
+$PHPMAILER_LANG['buggy_php']            = 'PHP sürümünüz iletilerin bozulmasına neden olabilecek bir hatadan etkileniyor. Bunu düzeltmek için, SMTP kullanarak göndermeye geçin, mail.add_x_header seçeneğini devre dışı bırakın php.ini dosyanızdaki mail.add_x_header seçeneğini devre dışı bırakın, MacOS veya Linux geçin veya PHP sürümünü 7.0.17+ veya 7.1.3+ sürümüne yükseltin,';
+$PHPMAILER_LANG['connect_host']         = 'SMTP Hatası: SMTP sunucusuna bağlanılamadı.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP Hatası: Veri kabul edilmedi.';
+$PHPMAILER_LANG['empty_message']        = 'Mesajın içeriği boş';
+$PHPMAILER_LANG['encoding']             = 'Bilinmeyen karakter kodlama: ';
+$PHPMAILER_LANG['execute']              = 'Çalıştırılamadı: ';
+$PHPMAILER_LANG['extension_missing']    = 'Eklenti bulunamadı: ';
+$PHPMAILER_LANG['file_access']          = 'Dosyaya erişilemedi: ';
+$PHPMAILER_LANG['file_open']            = 'Dosya Hatası: Dosya açılamadı: ';
+$PHPMAILER_LANG['from_failed']          = 'Belirtilen adreslere gönderme başarısız: ';
+$PHPMAILER_LANG['instantiate']          = 'Örnek e-posta fonksiyonu oluşturulamadı.';
+$PHPMAILER_LANG['invalid_address']      = 'Geçersiz e-posta adresi: ';
+$PHPMAILER_LANG['invalid_header']       = 'Geçersiz başlık adı veya değeri: ';
+$PHPMAILER_LANG['invalid_hostentry']    = 'Geçersiz ana bilgisayar girişi: ';
+$PHPMAILER_LANG['invalid_host']         = 'Geçersiz ana bilgisayar: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' e-posta kütüphanesi desteklenmiyor.';
+$PHPMAILER_LANG['provide_address']      = 'En az bir alıcı e-posta adresi belirtmelisiniz.';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP Hatası: Belirtilen alıcılara ulaşılamadı: ';
+$PHPMAILER_LANG['signing']              = 'İmzalama hatası: ';
+$PHPMAILER_LANG['smtp_code']            = 'SMTP kodu: ';
+$PHPMAILER_LANG['smtp_code_ex']         = 'ek SMTP bilgileri: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP connect() fonksiyonu başarısız.';
+$PHPMAILER_LANG['smtp_detail']          = 'SMTP SMTP Detayı: ';
+$PHPMAILER_LANG['smtp_error']           = 'SMTP sunucu hatası: ';
+$PHPMAILER_LANG['variable_set']         = 'Değişken ayarlanamadı ya da sıfırlanamadı: ';

--- a/language/phpmailer.lang-uk.php
+++ b/language/phpmailer.lang-uk.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Ukrainian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Yuriy Rudyy <yrudyy@prs.net.ua>
+ * @fixed by Boris Yurchenko <boris@yurchenko.pp.ua>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'Помилка SMTP: помилка авторизації.';
+$PHPMAILER_LANG['connect_host']         = 'Помилка SMTP: не вдається під\'єднатися до SMTP-серверу.';
+$PHPMAILER_LANG['data_not_accepted']    = 'Помилка SMTP: дані не прийнято.';
+$PHPMAILER_LANG['encoding']             = 'Невідоме кодування: ';
+$PHPMAILER_LANG['execute']              = 'Неможливо виконати команду: ';
+$PHPMAILER_LANG['file_access']          = 'Немає доступу до файлу: ';
+$PHPMAILER_LANG['file_open']            = 'Помилка файлової системи: не вдається відкрити файл: ';
+$PHPMAILER_LANG['from_failed']          = 'Невірна адреса відправника: ';
+$PHPMAILER_LANG['instantiate']          = 'Неможливо запустити функцію mail().';
+$PHPMAILER_LANG['provide_address']      = 'Будь ласка, введіть хоча б одну email-адресу отримувача.';
+$PHPMAILER_LANG['mailer_not_supported'] = ' - поштовий сервер не підтримується.';
+$PHPMAILER_LANG['recipients_failed']    = 'Помилка SMTP: не вдалося відправлення для таких отримувачів: ';
+$PHPMAILER_LANG['empty_message']        = 'Пусте повідомлення';
+$PHPMAILER_LANG['invalid_address']      = 'Не відправлено через неправильний формат email-адреси: ';
+$PHPMAILER_LANG['signing']              = 'Помилка підпису: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'Помилка з\'єднання з SMTP-сервером';
+$PHPMAILER_LANG['smtp_error']           = 'Помилка SMTP-сервера: ';
+$PHPMAILER_LANG['variable_set']         = 'Неможливо встановити або скинути змінну: ';
+$PHPMAILER_LANG['extension_missing']    = 'Розширення відсутнє: ';

--- a/language/phpmailer.lang-ur.php
+++ b/language/phpmailer.lang-ur.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Urdu PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Saqib Ali Siddiqui <saqibsra@gmail.com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP خرابی: تصدیق کرنے سے قاصر۔';
+$PHPMAILER_LANG['connect_host']         = 'SMTP خرابی: سرور سے منسلک ہونے سے قاصر۔';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP خرابی: ڈیٹا قبول نہیں کیا گیا۔';
+$PHPMAILER_LANG['empty_message']        = 'پیغام کی باڈی خالی ہے۔';
+$PHPMAILER_LANG['encoding']             = 'نامعلوم انکوڈنگ: ';
+$PHPMAILER_LANG['execute']              = 'عمل کرنے کے قابل نہیں ';
+$PHPMAILER_LANG['file_access']          = 'فائل تک رسائی سے قاصر:';
+$PHPMAILER_LANG['file_open']            = 'فائل کی خرابی: فائل کو کھولنے سے قاصر:';
+$PHPMAILER_LANG['from_failed']          = 'درج ذیل بھیجنے والے کا پتہ ناکام ہو گیا:';
+$PHPMAILER_LANG['instantiate']          = 'میل فنکشن کی مثال بنانے سے قاصر۔';
+$PHPMAILER_LANG['invalid_address']      = 'بھیجنے سے قاصر: غلط ای میل پتہ:';
+$PHPMAILER_LANG['mailer_not_supported'] = ' میلر تعاون یافتہ نہیں ہے۔';
+$PHPMAILER_LANG['provide_address']      = 'آپ کو کم از کم ایک منزل کا ای میل پتہ فراہم کرنا چاہیے۔';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP خرابی: درج ذیل پتہ پر نہیں بھیجا جاسکا: ';
+$PHPMAILER_LANG['signing']              = 'دستخط کی خرابی: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP ملنا ناکام ہوا';
+$PHPMAILER_LANG['smtp_error']           = 'SMTP سرور کی خرابی: ';
+$PHPMAILER_LANG['variable_set']         = 'متغیر سیٹ نہیں کیا جا سکا: ';
+$PHPMAILER_LANG['extension_missing']    = 'ایکٹینشن موجود نہیں ہے۔ ';
+$PHPMAILER_LANG['smtp_code']            = 'SMTP سرور کوڈ: ';
+$PHPMAILER_LANG['smtp_code_ex']         = 'اضافی SMTP سرور کی معلومات:';
+$PHPMAILER_LANG['invalid_header']       = 'غلط ہیڈر کا نام یا قدر';

--- a/language/phpmailer.lang-vi.php
+++ b/language/phpmailer.lang-vi.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Vietnamese (Tiếng Việt) PHPMailer language file: refer to English translation for definitive list.
+ * @package PHPMailer
+ * @author VINADES.,JSC <contact@vinades.vn>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'Lỗi SMTP: Không thể xác thực.';
+$PHPMAILER_LANG['connect_host']         = 'Lỗi SMTP: Không thể kết nối máy chủ SMTP.';
+$PHPMAILER_LANG['data_not_accepted']    = 'Lỗi SMTP: Dữ liệu không được chấp nhận.';
+$PHPMAILER_LANG['empty_message']        = 'Không có nội dung';
+$PHPMAILER_LANG['encoding']             = 'Mã hóa không xác định: ';
+$PHPMAILER_LANG['execute']              = 'Không thực hiện được: ';
+$PHPMAILER_LANG['file_access']          = 'Không thể truy cập tệp tin ';
+$PHPMAILER_LANG['file_open']            = 'Lỗi Tập tin: Không thể mở tệp tin: ';
+$PHPMAILER_LANG['from_failed']          = 'Lỗi địa chỉ gửi đi: ';
+$PHPMAILER_LANG['instantiate']          = 'Không dùng được các hàm gửi thư.';
+$PHPMAILER_LANG['invalid_address']      = 'Đại chỉ emai không đúng: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' trình gửi thư không được hỗ trợ.';
+$PHPMAILER_LANG['provide_address']      = 'Bạn phải cung cấp ít nhất một địa chỉ người nhận.';
+$PHPMAILER_LANG['recipients_failed']    = 'Lỗi SMTP: lỗi địa chỉ người nhận: ';
+$PHPMAILER_LANG['signing']              = 'Lỗi đăng nhập: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'Lỗi kết nối với SMTP';
+$PHPMAILER_LANG['smtp_error']           = 'Lỗi máy chủ smtp ';
+$PHPMAILER_LANG['variable_set']         = 'Không thể thiết lập hoặc thiết lập lại biến: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/language/phpmailer.lang-zh.php
+++ b/language/phpmailer.lang-zh.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Traditional Chinese PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author liqwei <liqwei@liqwei.com>
+ * @author Peter Dave Hello <@PeterDaveHello/>
+ * @author Jason Chiang <xcojad@gmail.com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP 錯誤：登入失敗。';
+$PHPMAILER_LANG['connect_host']         = 'SMTP 錯誤：無法連線到 SMTP 主機。';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP 錯誤：無法接受的資料。';
+$PHPMAILER_LANG['empty_message']        = '郵件內容為空';
+$PHPMAILER_LANG['encoding']             = '未知編碼: ';
+$PHPMAILER_LANG['execute']              = '無法執行：';
+$PHPMAILER_LANG['file_access']          = '無法存取檔案：';
+$PHPMAILER_LANG['file_open']            = '檔案錯誤：無法開啟檔案：';
+$PHPMAILER_LANG['from_failed']          = '發送地址錯誤：';
+$PHPMAILER_LANG['instantiate']          = '未知函數呼叫。';
+$PHPMAILER_LANG['invalid_address']      = '因為電子郵件地址無效，無法傳送: ';
+$PHPMAILER_LANG['mailer_not_supported'] = '不支援的發信客戶端。';
+$PHPMAILER_LANG['provide_address']      = '必須提供至少一個收件人地址。';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP 錯誤：以下收件人地址錯誤：';
+$PHPMAILER_LANG['signing']              = '電子簽章錯誤: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP 連線失敗';
+$PHPMAILER_LANG['smtp_error']           = 'SMTP 伺服器錯誤: ';
+$PHPMAILER_LANG['variable_set']         = '無法設定或重設變數: ';
+$PHPMAILER_LANG['extension_missing']    = '遺失模組 Extension: ';

--- a/language/phpmailer.lang-zh_cn.php
+++ b/language/phpmailer.lang-zh_cn.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Simplified Chinese PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author liqwei <liqwei@liqwei.com>
+ * @author young <masxy@foxmail.com>
+ * @author Teddysun <i@teddysun.com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP 错误：登录失败。';
+$PHPMAILER_LANG['buggy_php']            = '您的 PHP 版本存在漏洞，可能会导致消息损坏。为修复此问题，请切换到使用 SMTP 发送，在您的 php.ini 中禁用 mail.add_x_header 选项。切换到 MacOS 或 Linux，或将您的 PHP 升级到 7.0.17+ 或 7.1.3+ 版本。';
+$PHPMAILER_LANG['connect_host']         = 'SMTP 错误：无法连接到 SMTP 主机。';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP 错误：数据不被接受。';
+$PHPMAILER_LANG['empty_message']        = '邮件正文为空。';
+$PHPMAILER_LANG['encoding']             = '未知编码：';
+$PHPMAILER_LANG['execute']              = '无法执行：';
+$PHPMAILER_LANG['extension_missing']    = '缺少扩展名：';
+$PHPMAILER_LANG['file_access']          = '无法访问文件：';
+$PHPMAILER_LANG['file_open']            = '文件错误：无法打开文件：';
+$PHPMAILER_LANG['from_failed']          = '发送地址错误：';
+$PHPMAILER_LANG['instantiate']          = '未知函数调用。';
+$PHPMAILER_LANG['invalid_address']      = '发送失败，电子邮箱地址是无效的：';
+$PHPMAILER_LANG['mailer_not_supported'] = '发信客户端不被支持。';
+$PHPMAILER_LANG['provide_address']      = '必须提供至少一个收件人地址。';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP 错误：收件人地址错误：';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP服务器连接失败。';
+$PHPMAILER_LANG['smtp_error']           = 'SMTP服务器出错：';
+$PHPMAILER_LANG['variable_set']         = '无法设置或重置变量：';
+$PHPMAILER_LANG['invalid_header']       = '无效的标题名称或值';
+$PHPMAILER_LANG['invalid_hostentry']    = '无效的hostentry： ';
+$PHPMAILER_LANG['invalid_host']         = '无效的主机：';
+$PHPMAILER_LANG['signing']              = '签名错误：';
+$PHPMAILER_LANG['smtp_code']            = 'SMTP代码： ';
+$PHPMAILER_LANG['smtp_code_ex']         = '附加SMTP信息： ';
+$PHPMAILER_LANG['smtp_detail']          = '详情:';


### PR DESCRIPTION
## Title
feat: implement export evaluation admin

## Description
[Describe what you changed to add CSV export functionality]

## Related User Story
**US-09:** As a admin, I should be able to export reports in CSV format, so that I can submit official copies to office.

## Changes Made
- [x] Added Export button
- [x] Implemented CSV file generation
- [x] Added file download functionality


## How to Test
1. Login as admin
2. Generate a report
3. Click Export button
4. Verify CSV file downloads
5. Check file content

## Test Cases

| Test Case | Expected Result | Status |
|-----------|----------------|--------|
| TC-01: Click Export | CSV file downloads | ⬜ Pending |
| TC-02: File content | Matches displayed report data | ⬜ Pending |
| TC-03: Export failure | Error message displayed | ⬜ Pending |

## Acceptance Criteria Checklist

- [x] Exported file matches displayed report data
- [x] CSV file format is readable and complete

